### PR TITLE
Introduce Uber Shader SVN#132

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "zig build -Dztracy-enable=false -Dtarget=native-native-msvc --summary failures",
+            "command": "zig build -Dztracy-enable=true -Dtarget=native-native-msvc --summary failures",
             // "command": "zig build -Dztracy-enable=false -Dtarget=native-native-msvc --summary failures -freference-trace --verbose",
             "group": "build",
             "problemMatcher": [

--- a/src/config/flecs_data.zig
+++ b/src/config/flecs_data.zig
@@ -335,9 +335,17 @@ pub const SurfaceType = enum {
     masked,
 };
 
-pub const UberShader = struct {
-    surface_type: SurfaceType,
+pub const ShadingTechnique = enum {
+    gbuffer,
+    shadow_caster,
+};
 
+pub const UberShader = struct {
+    // Techniques
+    gbuffer_pipeline_id: ?IdLocal,
+    shadow_caster_pipeline_id: ?IdLocal,
+
+    // Basic PBR Surface Data
     base_color: ColorRGB,
     metallic: f32,
     roughness: f32,
@@ -348,11 +356,13 @@ pub const UberShader = struct {
     arm: TextureHandle,
     emissive: TextureHandle,
 
+    // Wind Feature
     wind_feature: bool,
     wind_initial_bend: f32,
     wind_stifness: f32,
     wind_drag: f32,
 
+    // Wind Shiver Feature
     wind_shiver_feature: bool,
     wind_shiver_drag: f32,
     wind_shiver_directionality: f32,
@@ -360,7 +370,8 @@ pub const UberShader = struct {
 
     pub fn init() UberShader {
         return .{
-            .surface_type = .@"opaque",
+            .gbuffer_pipeline_id = null,
+            .shadow_caster_pipeline_id = null,
             .base_color = ColorRGB.init(1, 1, 1),
             .roughness = 0.8,
             .metallic = 0,
@@ -383,8 +394,8 @@ pub const UberShader = struct {
 
     pub fn initNoTexture(base_color: ColorRGB, roughness: f32, metallic: f32) UberShader {
         return .{
-            .surface_type = .@"opaque",
-
+            .gbuffer_pipeline_id = null,
+            .shadow_caster_pipeline_id = null,
             .base_color = base_color,
             .roughness = roughness,
             .metallic = metallic,

--- a/src/config/flecs_data.zig
+++ b/src/config/flecs_data.zig
@@ -392,7 +392,7 @@ pub const StaticMesh = struct {
     mesh_handle: MeshHandle,
 
     material_count: u32,
-    materials: [renderer.sub_mesh_max_count]PBRMaterial,
+    materials: [renderer.sub_mesh_max_count]IdLocal,
 };
 
 // ███████╗██╗  ██╗██╗   ██╗██████╗  ██████╗ ██╗  ██╗

--- a/src/config/flecs_data.zig
+++ b/src/config/flecs_data.zig
@@ -335,7 +335,9 @@ pub const SurfaceType = enum {
     masked,
 };
 
-pub const PBRMaterial = struct {
+pub const UberShader = struct {
+    surface_type: SurfaceType,
+
     base_color: ColorRGB,
     metallic: f32,
     roughness: f32,
@@ -345,10 +347,20 @@ pub const PBRMaterial = struct {
     normal: TextureHandle,
     arm: TextureHandle,
     emissive: TextureHandle,
-    surface_type: SurfaceType,
 
-    pub fn init() PBRMaterial {
+    wind_feature: bool,
+    wind_initial_bend: f32,
+    wind_stifness: f32,
+    wind_drag: f32,
+
+    wind_shiver_feature: bool,
+    wind_shiver_drag: f32,
+    wind_shiver_directionality: f32,
+    wind_normal_influence: f32,
+
+    pub fn init() UberShader {
         return .{
+            .surface_type = .@"opaque",
             .base_color = ColorRGB.init(1, 1, 1),
             .roughness = 0.8,
             .metallic = 0,
@@ -358,12 +370,21 @@ pub const PBRMaterial = struct {
             .normal = TextureHandle.nil,
             .arm = TextureHandle.nil,
             .emissive = TextureHandle.nil,
-            .surface_type = .@"opaque",
+            .wind_feature = false,
+            .wind_initial_bend = 1.0,
+            .wind_stifness = 1.0,
+            .wind_drag = 0.1,
+            .wind_shiver_feature = false,
+            .wind_shiver_drag = 0.1,
+            .wind_normal_influence = 0,
+            .wind_shiver_directionality = 0.4,
         };
     }
 
-    pub fn initNoTexture(base_color: ColorRGB, roughness: f32, metallic: f32) PBRMaterial {
+    pub fn initNoTexture(base_color: ColorRGB, roughness: f32, metallic: f32) UberShader {
         return .{
+            .surface_type = .@"opaque",
+
             .base_color = base_color,
             .roughness = roughness,
             .metallic = metallic,
@@ -373,7 +394,14 @@ pub const PBRMaterial = struct {
             .normal = TextureHandle.nil,
             .arm = TextureHandle.nil,
             .emissive = TextureHandle.nil,
-            .surface_type = .@"opaque",
+            .wind_feature = false,
+            .wind_initial_bend = 1.0,
+            .wind_stifness = 1.0,
+            .wind_drag = 0.1,
+            .wind_shiver_feature = false,
+            .wind_shiver_drag = 0.1,
+            .wind_normal_influence = 0,
+            .wind_shiver_directionality = 0.4,
         };
     }
 };

--- a/src/config/prefab.zig
+++ b/src/config/prefab.zig
@@ -4,6 +4,7 @@ const core = @import("../core/core.zig");
 const ecsu = @import("../flecs_util/flecs_util.zig");
 const fd = @import("flecs_data.zig");
 const renderer = @import("../renderer/renderer.zig");
+const IdLocal = core.IdLocal;
 const ID = @import("../core/core.zig").ID;
 
 pub var player: ecsu.Entity = undefined;
@@ -13,12 +14,11 @@ pub var default_cube: ecsu.Entity = undefined;
 pub var matball: ecsu.Entity = undefined;
 
 pub const arrow_id = ID("prefab_arrow");
-pub const beech_tree_01_id = ID("beech_tree_02");
+pub const beech_tree_04_id = ID("beech_tree_04");
 pub const bow_id = ID("prefab_bow");
 pub const cube_id = ID("prefab_cube");
 pub const cylinder_id = ID("prefab_cylinder");
 pub const debug_sphere_id = ID("prefab_debug_sphere");
-pub const fir_id = ID("prefab_fir");
 pub const giant_ant_id = ID("prefab_giant_ant");
 pub const matball_id = ID("prefab_matball");
 pub const medium_house_id = ID("prefab_medium_house");
@@ -26,53 +26,71 @@ pub const player_id = ID("prefab_player");
 pub const sphere_id = ID("prefab_sphere");
 
 pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.World) void {
+    const default_material = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+    const default_material_id = IdLocal.init("M_default");
+    prefab_mgr.storeMaterial(default_material_id, default_material);
+
     {
         player = prefab_mgr.loadPrefabFromBinary("prefabs/characters/player/player.bin", player_id, ecsu_world);
         player.setOverride(fd.Dynamic{});
+
         const static_mesh_component = player.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+            static_mesh.materials[0] = default_material_id;
         }
     }
 
     {
+        var material = fd.PBRMaterial.init();
+        material.albedo = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_albedo.dds");
+        material.arm = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_arm.dds");
+        material.normal = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_normal.dds");
+        const material_id = IdLocal.init("M_round_aluminium_panel");
+        prefab_mgr.storeMaterial(material_id, material);
+
         matball = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/matball.bin", matball_id, ecsu_world);
         matball.setOverride(fd.Dynamic{});
+
         const static_mesh_component = matball.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+            static_mesh.materials[0] = material_id;
         }
     }
 
     {
+        var material = fd.PBRMaterial.init();
+        material.albedo = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_albedo.dds");
+        material.arm = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_arm.dds");
+        material.normal = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_normal.dds");
+        const material_id = IdLocal.init("M_giant_ant");
+        prefab_mgr.storeMaterial(material_id, material);
+
         giant_ant = prefab_mgr.loadPrefabFromBinary("prefabs/creatures/giant_ant/giant_ant.bin", giant_ant_id, ecsu_world);
         giant_ant.setOverride(fd.Dynamic{});
+
         const static_mesh_component = giant_ant.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_albedo.dds");
-            static_mesh.materials[0].arm = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_arm.dds");
-            static_mesh.materials[0].normal = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_normal.dds");
+            static_mesh.materials[0] = material_id;
         }
     }
 
     {
-        const albedo = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_albedo.dds");
-        const arm = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_arm.dds");
-        const normal = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_normal.dds");
+        var material = fd.PBRMaterial.init();
+        material.albedo = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_albedo.dds");
+        material.arm = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_arm.dds");
+        material.normal = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_normal.dds");
+        const material_id = IdLocal.init("M_bow");
+        prefab_mgr.storeMaterial(material_id, material);
 
         bow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/bow.bin", bow_id, ecsu_world);
         bow.setOverride(fd.Dynamic{});
         var static_mesh_component = bow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = albedo;
-            static_mesh.materials[0].arm = arm;
-            static_mesh.materials[0].normal = normal;
+            static_mesh.materials[0] = material_id;
         }
 
         var arrow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/arrow.bin", arrow_id, ecsu_world);
@@ -80,10 +98,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         static_mesh_component = arrow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = albedo;
-            static_mesh.materials[0].arm = arm;
-            static_mesh.materials[0].normal = normal;
+            static_mesh.materials[0] = material_id;
         }
     }
 
@@ -93,7 +108,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         const static_mesh_component = default_cube.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+            static_mesh.materials[0] = default_material_id;
         }
     }
 
@@ -103,7 +118,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         const static_mesh_component = cylinder.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+            static_mesh.materials[0] = default_material_id;
         }
     }
 
@@ -113,90 +128,74 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         const static_mesh_component = sphere.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 1;
-            static_mesh.materials[0] = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+            static_mesh.materials[0] = default_material_id;
         }
     }
 
     {
+        var roof_material = fd.PBRMaterial.init();
+        roof_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_albedo.dds");
+        roof_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_arm.dds");
+        roof_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_normal.dds");
+        const roof_material_id = IdLocal.init("M_medium_house_roof");
+        prefab_mgr.storeMaterial(roof_material_id, roof_material);
+
+        var wood_material = fd.PBRMaterial.init();
+        wood_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_albedo.dds");
+        wood_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_arm.dds");
+        wood_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_normal.dds");
+        const wood_material_id = IdLocal.init("M_medium_house_wood");
+        prefab_mgr.storeMaterial(wood_material_id, wood_material);
+
+        var plaster_material = fd.PBRMaterial.init();
+        plaster_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_albedo.dds");
+        plaster_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_arm.dds");
+        plaster_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_normal.dds");
+        const plaster_material_id = IdLocal.init("M_medium_house_plaster");
+        prefab_mgr.storeMaterial(plaster_material_id, plaster_material);
+
+        var stone_material = fd.PBRMaterial.init();
+        stone_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_albedo.dds");
+        stone_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_arm.dds");
+        stone_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_normal.dds");
+        const stone_material_id = IdLocal.init("M_medium_house_stone");
+        prefab_mgr.storeMaterial(stone_material_id, stone_material);
+
         var medium_house = prefab_mgr.loadPrefabFromBinary("prefabs/buildings/medium_house/medium_house.bin", medium_house_id, ecsu_world);
         const static_mesh_component = medium_house.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 4;
 
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_albedo.dds");
-            static_mesh.materials[0].arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_arm.dds");
-            static_mesh.materials[0].normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_normal.dds");
-
-            static_mesh.materials[1] = fd.PBRMaterial.init();
-            static_mesh.materials[1].albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_albedo.dds");
-            static_mesh.materials[1].arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_arm.dds");
-            static_mesh.materials[1].normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_normal.dds");
-
-            static_mesh.materials[2] = fd.PBRMaterial.init();
-            static_mesh.materials[2].albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_albedo.dds");
-            static_mesh.materials[2].arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_arm.dds");
-            static_mesh.materials[2].normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_normal.dds");
-
-            static_mesh.materials[3] = fd.PBRMaterial.init();
-            static_mesh.materials[3].albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_albedo.dds");
-            static_mesh.materials[3].arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_arm.dds");
-            static_mesh.materials[3].normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_normal.dds");
+            static_mesh.materials[0] = roof_material_id;
+            static_mesh.materials[1] = wood_material_id;
+            static_mesh.materials[2] = plaster_material_id;
+            static_mesh.materials[3] = stone_material_id;
         }
     }
 
     {
-        var beech_tree_01 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/beech_tree_01.bin", beech_tree_01_id, ecsu_world);
-        const static_mesh_component = beech_tree_01.getMut(fd.StaticMesh);
+        var beech_trunk_04_material = fd.PBRMaterial.init();
+        beech_trunk_04_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_albedo.dds");
+        beech_trunk_04_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_arm.dds");
+        beech_trunk_04_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_normal.dds");
+        const beech_trunk_04_material_id = IdLocal.init("M_beech_trunk_04");
+        prefab_mgr.storeMaterial(beech_trunk_04_material_id, beech_trunk_04_material);
+
+        var beech_atlas_v2_material = fd.PBRMaterial.init();
+        beech_atlas_v2_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_v2_albedo.dds");
+        beech_atlas_v2_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_arm.dds");
+        beech_atlas_v2_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_normal.dds");
+        beech_atlas_v2_material.surface_type = .masked;
+        const beech_atlas_v2_material_id = IdLocal.init("M_beech_atlas_v2");
+        prefab_mgr.storeMaterial(beech_atlas_v2_material_id, beech_atlas_v2_material);
+
+        var beech_tree_04 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/prefab_beech_tree_04_LOD0.bin", beech_tree_04_id, ecsu_world);
+        const static_mesh_component = beech_tree_04.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 2;
 
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_bark_02_BC.dds");
-            static_mesh.materials[0].arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_bark_02_ARM.dds");
-            static_mesh.materials[0].normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_bark_02_N.dds");
-
-            static_mesh.materials[1] = fd.PBRMaterial.init();
-            static_mesh.materials[1].albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_atlas_BC.dds");
-            static_mesh.materials[1].arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_atlas_ARM.dds");
-            static_mesh.materials[1].normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/T_beech_atlas_N.dds");
-            static_mesh.materials[1].surface_type = .masked;
-        }
-    }
-
-    {
-        var fir = prefab_mgr.loadPrefabFromBinary("prefabs/environment/fir/fir.bin", fir_id, ecsu_world);
-        const static_mesh_component = fir.getMut(fd.StaticMesh);
-        if (static_mesh_component) |static_mesh| {
-            static_mesh.material_count = 2;
-
-            static_mesh.materials[0] = fd.PBRMaterial.init();
-            static_mesh.materials[0].albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/fir/fir_bark_albedo.dds");
-
-            static_mesh.materials[1] = fd.PBRMaterial.init();
-            static_mesh.materials[1].albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/fir/fir_branch_albedo.dds");
-            static_mesh.materials[1].surface_type = .masked;
-        }
-    }
-
-    {
-        var sphere_test = prefab_mgr.loadPrefabFromBinary("prefabs/props/debug_sphere/debug_sphere.bin", debug_sphere_id, ecsu_world);
-        const static_mesh_component = sphere_test.getMut(fd.StaticMesh);
-        if (static_mesh_component) |static_mesh| {
-            static_mesh.material_count = 22;
-
-            for (0..11) |i| {
-                const roughness: f32 = @as(f32, @floatFromInt(i)) / 10.0;
-                static_mesh.materials[i] = fd.PBRMaterial.init();
-                static_mesh.materials[i].base_color = fd.ColorRGB.init(1.0, 1.0, 1.0);
-                static_mesh.materials[i].metallic = 0.0;
-                static_mesh.materials[i].roughness = roughness;
-
-                static_mesh.materials[i + 11] = fd.PBRMaterial.init();
-                static_mesh.materials[i + 11].base_color = fd.ColorRGB.init(1.0, 1.0, 1.0);
-                static_mesh.materials[i + 11].metallic = 1.0;
-                static_mesh.materials[i + 11].roughness = roughness;
-            }
+            static_mesh.materials[0] = beech_trunk_04_material_id;
+            static_mesh.materials[1] = beech_atlas_v2_material_id;
         }
     }
 }

--- a/src/config/prefab.zig
+++ b/src/config/prefab.zig
@@ -27,14 +27,29 @@ pub const sphere_id = ID("prefab_sphere");
 
 // TODO(gmodarelli): We need an Asset Database to store meshes, textures, materials and prefabs instead of managing them all through prefabs
 pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.World) void {
-    const default_material = fd.UberShader.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+    const pipeline_lit_opaque_id = IdLocal.init("lit");
+    const pipeline_lit_masked_id = IdLocal.init("lit_masked");
+    _ = pipeline_lit_masked_id;
+    const pipeline_tree_opaque_id = IdLocal.init("tree");
+    const pipeline_tree_masked_id = IdLocal.init("tree_masked");
+
+    const pipeline_shadow_caster_opaque_id = IdLocal.init("shadows_lit");
+    const pipeline_shadow_caster_masked_id = IdLocal.init("shadows_lit_masked");
+    _ = pipeline_shadow_caster_masked_id;
+    const pipeline_tree_shadow_caster_opaque_id = IdLocal.init("shadows_tree");
+    const pipeline_tree_shadow_caster_masked_id = IdLocal.init("shadows_tree_masked");
+
+    var default_material = fd.UberShader.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+    default_material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+    default_material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
     const default_material_id = IdLocal.init("M_default");
     prefab_mgr.storeMaterial(default_material_id, default_material);
 
-    const vertex_layout_id = IdLocal.init("pos_uv0_nor_tan_col");
+    const pos_uv0_nor_tan_col_vertex_layout = IdLocal.init("pos_uv0_nor_tan_col");
+    const pos_uv0_nor_tan_col_uv1_vertex_layout = IdLocal.init("pos_uv0_nor_tan_col_uv1");
 
     {
-        player = prefab_mgr.loadPrefabFromBinary("prefabs/characters/player/player.bin", player_id, vertex_layout_id, ecsu_world);
+        player = prefab_mgr.loadPrefabFromBinary("prefabs/characters/player/player.bin", player_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         player.setOverride(fd.Dynamic{});
 
         const static_mesh_component = player.getMut(fd.StaticMesh);
@@ -46,13 +61,15 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
 
     {
         var material = fd.UberShader.init();
+        material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         material.albedo = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_normal.dds");
         const material_id = IdLocal.init("M_round_aluminium_panel");
         prefab_mgr.storeMaterial(material_id, material);
 
-        matball = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/matball.bin", matball_id, vertex_layout_id, ecsu_world);
+        matball = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/matball.bin", matball_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         matball.setOverride(fd.Dynamic{});
 
         const static_mesh_component = matball.getMut(fd.StaticMesh);
@@ -64,13 +81,15 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
 
     {
         var material = fd.UberShader.init();
+        material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         material.albedo = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_normal.dds");
         const material_id = IdLocal.init("M_giant_ant");
         prefab_mgr.storeMaterial(material_id, material);
 
-        giant_ant = prefab_mgr.loadPrefabFromBinary("prefabs/creatures/giant_ant/giant_ant.bin", giant_ant_id, vertex_layout_id, ecsu_world);
+        giant_ant = prefab_mgr.loadPrefabFromBinary("prefabs/creatures/giant_ant/giant_ant.bin", giant_ant_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         giant_ant.setOverride(fd.Dynamic{});
 
         const static_mesh_component = giant_ant.getMut(fd.StaticMesh);
@@ -82,13 +101,15 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
 
     {
         var material = fd.UberShader.init();
+        material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         material.albedo = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_normal.dds");
         const material_id = IdLocal.init("M_bow");
         prefab_mgr.storeMaterial(material_id, material);
 
-        bow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/bow.bin", bow_id, vertex_layout_id, ecsu_world);
+        bow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/bow.bin", bow_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         bow.setOverride(fd.Dynamic{});
         var static_mesh_component = bow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -96,7 +117,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
             static_mesh.materials[0] = material_id;
         }
 
-        var arrow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/arrow.bin", arrow_id, vertex_layout_id, ecsu_world);
+        var arrow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/arrow.bin", arrow_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         arrow.setOverride(fd.Dynamic{});
         static_mesh_component = arrow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -106,7 +127,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        default_cube = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cube.bin", cube_id, vertex_layout_id, ecsu_world);
+        default_cube = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cube.bin", cube_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         default_cube.setOverride(fd.Dynamic{});
         const static_mesh_component = default_cube.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -116,7 +137,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var cylinder = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cylinder.bin", cylinder_id, vertex_layout_id, ecsu_world);
+        var cylinder = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cylinder.bin", cylinder_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         cylinder.setOverride(fd.Dynamic{});
         const static_mesh_component = cylinder.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -126,7 +147,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var sphere = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_sphere.bin", sphere_id, vertex_layout_id, ecsu_world);
+        var sphere = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_sphere.bin", sphere_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         sphere.setOverride(fd.Dynamic{});
         const static_mesh_component = sphere.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -137,6 +158,8 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
 
     {
         var roof_material = fd.UberShader.init();
+        roof_material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        roof_material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         roof_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_albedo.dds");
         roof_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_arm.dds");
         roof_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_normal.dds");
@@ -144,6 +167,8 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         prefab_mgr.storeMaterial(roof_material_id, roof_material);
 
         var wood_material = fd.UberShader.init();
+        wood_material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        wood_material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         wood_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_albedo.dds");
         wood_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_arm.dds");
         wood_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_normal.dds");
@@ -151,6 +176,8 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         prefab_mgr.storeMaterial(wood_material_id, wood_material);
 
         var plaster_material = fd.UberShader.init();
+        plaster_material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        plaster_material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         plaster_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_albedo.dds");
         plaster_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_arm.dds");
         plaster_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_normal.dds");
@@ -158,13 +185,15 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         prefab_mgr.storeMaterial(plaster_material_id, plaster_material);
 
         var stone_material = fd.UberShader.init();
+        stone_material.gbuffer_pipeline_id = pipeline_lit_opaque_id;
+        stone_material.shadow_caster_pipeline_id = pipeline_shadow_caster_opaque_id;
         stone_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_albedo.dds");
         stone_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_arm.dds");
         stone_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_normal.dds");
         const stone_material_id = IdLocal.init("M_medium_house_stone");
         prefab_mgr.storeMaterial(stone_material_id, stone_material);
 
-        var medium_house = prefab_mgr.loadPrefabFromBinary("prefabs/buildings/medium_house/medium_house.bin", medium_house_id, vertex_layout_id, ecsu_world);
+        var medium_house = prefab_mgr.loadPrefabFromBinary("prefabs/buildings/medium_house/medium_house.bin", medium_house_id, pos_uv0_nor_tan_col_vertex_layout, ecsu_world);
         const static_mesh_component = medium_house.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 4;
@@ -178,6 +207,8 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
 
     {
         var beech_trunk_04_material = fd.UberShader.init();
+        beech_trunk_04_material.gbuffer_pipeline_id = pipeline_tree_opaque_id;
+        beech_trunk_04_material.shadow_caster_pipeline_id = pipeline_tree_shadow_caster_opaque_id;
         beech_trunk_04_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_albedo.dds");
         beech_trunk_04_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_arm.dds");
         beech_trunk_04_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_normal.dds");
@@ -189,7 +220,8 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         prefab_mgr.storeMaterial(beech_trunk_04_material_id, beech_trunk_04_material);
 
         var beech_atlas_v2_material = fd.UberShader.init();
-        beech_atlas_v2_material.surface_type = .masked;
+        beech_atlas_v2_material.gbuffer_pipeline_id = pipeline_tree_masked_id;
+        beech_atlas_v2_material.shadow_caster_pipeline_id = pipeline_tree_shadow_caster_masked_id;
         beech_atlas_v2_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_v2_albedo.dds");
         beech_atlas_v2_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_arm.dds");
         beech_atlas_v2_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_normal.dds");
@@ -204,7 +236,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         const beech_atlas_v2_material_id = IdLocal.init("M_beech_atlas_v2");
         prefab_mgr.storeMaterial(beech_atlas_v2_material_id, beech_atlas_v2_material);
 
-        var beech_tree_04 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/prefab_beech_tree_04_LOD0.bin", beech_tree_04_id, vertex_layout_id, ecsu_world);
+        var beech_tree_04 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/beech_tree_04_LOD0.bin", beech_tree_04_id, pos_uv0_nor_tan_col_uv1_vertex_layout, ecsu_world);
         const static_mesh_component = beech_tree_04.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 2;

--- a/src/config/prefab.zig
+++ b/src/config/prefab.zig
@@ -212,7 +212,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         beech_trunk_04_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_albedo.dds");
         beech_trunk_04_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_arm.dds");
         beech_trunk_04_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_normal.dds");
-        beech_trunk_04_material.wind_feature = true;
+        beech_trunk_04_material.wind_feature = false;
         beech_trunk_04_material.wind_initial_bend = 1.0;
         beech_trunk_04_material.wind_stifness = 1.0;
         beech_trunk_04_material.wind_drag = 0.1;
@@ -225,11 +225,11 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
         beech_atlas_v2_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_v2_albedo.dds");
         beech_atlas_v2_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_arm.dds");
         beech_atlas_v2_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_normal.dds");
-        beech_atlas_v2_material.wind_feature = true;
+        beech_atlas_v2_material.wind_feature = false;
         beech_atlas_v2_material.wind_initial_bend = 1.0;
         beech_atlas_v2_material.wind_stifness = 1.0;
         beech_atlas_v2_material.wind_drag = 0.1;
-        beech_atlas_v2_material.wind_shiver_feature = true;
+        beech_atlas_v2_material.wind_shiver_feature = false;
         beech_atlas_v2_material.wind_shiver_drag = 0.1;
         beech_atlas_v2_material.wind_normal_influence = 0.2;
         beech_atlas_v2_material.wind_shiver_directionality = 0.4;

--- a/src/config/prefab.zig
+++ b/src/config/prefab.zig
@@ -25,13 +25,16 @@ pub const medium_house_id = ID("prefab_medium_house");
 pub const player_id = ID("prefab_player");
 pub const sphere_id = ID("prefab_sphere");
 
+// TODO(gmodarelli): We need an Asset Database to store meshes, textures, materials and prefabs instead of managing them all through prefabs
 pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.World) void {
-    const default_material = fd.PBRMaterial.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
+    const default_material = fd.UberShader.initNoTexture(fd.ColorRGB.init(1, 1, 1), 0.8, 0.0);
     const default_material_id = IdLocal.init("M_default");
     prefab_mgr.storeMaterial(default_material_id, default_material);
 
+    const vertex_layout_id = IdLocal.init("pos_uv0_nor_tan_col");
+
     {
-        player = prefab_mgr.loadPrefabFromBinary("prefabs/characters/player/player.bin", player_id, ecsu_world);
+        player = prefab_mgr.loadPrefabFromBinary("prefabs/characters/player/player.bin", player_id, vertex_layout_id, ecsu_world);
         player.setOverride(fd.Dynamic{});
 
         const static_mesh_component = player.getMut(fd.StaticMesh);
@@ -42,14 +45,14 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var material = fd.PBRMaterial.init();
+        var material = fd.UberShader.init();
         material.albedo = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("textures/debug/round_aluminum_panel_normal.dds");
         const material_id = IdLocal.init("M_round_aluminium_panel");
         prefab_mgr.storeMaterial(material_id, material);
 
-        matball = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/matball.bin", matball_id, ecsu_world);
+        matball = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/matball.bin", matball_id, vertex_layout_id, ecsu_world);
         matball.setOverride(fd.Dynamic{});
 
         const static_mesh_component = matball.getMut(fd.StaticMesh);
@@ -60,14 +63,14 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var material = fd.PBRMaterial.init();
+        var material = fd.UberShader.init();
         material.albedo = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("prefabs/creatures/giant_ant/giant_ant_normal.dds");
         const material_id = IdLocal.init("M_giant_ant");
         prefab_mgr.storeMaterial(material_id, material);
 
-        giant_ant = prefab_mgr.loadPrefabFromBinary("prefabs/creatures/giant_ant/giant_ant.bin", giant_ant_id, ecsu_world);
+        giant_ant = prefab_mgr.loadPrefabFromBinary("prefabs/creatures/giant_ant/giant_ant.bin", giant_ant_id, vertex_layout_id, ecsu_world);
         giant_ant.setOverride(fd.Dynamic{});
 
         const static_mesh_component = giant_ant.getMut(fd.StaticMesh);
@@ -78,14 +81,14 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var material = fd.PBRMaterial.init();
+        var material = fd.UberShader.init();
         material.albedo = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_albedo.dds");
         material.arm = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_arm.dds");
         material.normal = prefab_mgr.rctx.loadTexture("prefabs/props/bow_arrow/bow_arrow_normal.dds");
         const material_id = IdLocal.init("M_bow");
         prefab_mgr.storeMaterial(material_id, material);
 
-        bow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/bow.bin", bow_id, ecsu_world);
+        bow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/bow.bin", bow_id, vertex_layout_id, ecsu_world);
         bow.setOverride(fd.Dynamic{});
         var static_mesh_component = bow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -93,7 +96,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
             static_mesh.materials[0] = material_id;
         }
 
-        var arrow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/arrow.bin", arrow_id, ecsu_world);
+        var arrow = prefab_mgr.loadPrefabFromBinary("prefabs/props/bow_arrow/arrow.bin", arrow_id, vertex_layout_id, ecsu_world);
         arrow.setOverride(fd.Dynamic{});
         static_mesh_component = arrow.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -103,7 +106,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        default_cube = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cube.bin", cube_id, ecsu_world);
+        default_cube = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cube.bin", cube_id, vertex_layout_id, ecsu_world);
         default_cube.setOverride(fd.Dynamic{});
         const static_mesh_component = default_cube.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -113,7 +116,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var cylinder = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cylinder.bin", cylinder_id, ecsu_world);
+        var cylinder = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_cylinder.bin", cylinder_id, vertex_layout_id, ecsu_world);
         cylinder.setOverride(fd.Dynamic{});
         const static_mesh_component = cylinder.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -123,7 +126,7 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var sphere = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_sphere.bin", sphere_id, ecsu_world);
+        var sphere = prefab_mgr.loadPrefabFromBinary("prefabs/primitives/primitive_sphere.bin", sphere_id, vertex_layout_id, ecsu_world);
         sphere.setOverride(fd.Dynamic{});
         const static_mesh_component = sphere.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
@@ -133,35 +136,35 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var roof_material = fd.PBRMaterial.init();
+        var roof_material = fd.UberShader.init();
         roof_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_albedo.dds");
         roof_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_arm.dds");
         roof_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_roof_normal.dds");
         const roof_material_id = IdLocal.init("M_medium_house_roof");
         prefab_mgr.storeMaterial(roof_material_id, roof_material);
 
-        var wood_material = fd.PBRMaterial.init();
+        var wood_material = fd.UberShader.init();
         wood_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_albedo.dds");
         wood_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_arm.dds");
         wood_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_wood_normal.dds");
         const wood_material_id = IdLocal.init("M_medium_house_wood");
         prefab_mgr.storeMaterial(wood_material_id, wood_material);
 
-        var plaster_material = fd.PBRMaterial.init();
+        var plaster_material = fd.UberShader.init();
         plaster_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_albedo.dds");
         plaster_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_arm.dds");
         plaster_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_plaster_normal.dds");
         const plaster_material_id = IdLocal.init("M_medium_house_plaster");
         prefab_mgr.storeMaterial(plaster_material_id, plaster_material);
 
-        var stone_material = fd.PBRMaterial.init();
+        var stone_material = fd.UberShader.init();
         stone_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_albedo.dds");
         stone_material.arm = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_arm.dds");
         stone_material.normal = prefab_mgr.rctx.loadTexture("prefabs/buildings/medium_house/medium_house_stone_normal.dds");
         const stone_material_id = IdLocal.init("M_medium_house_stone");
         prefab_mgr.storeMaterial(stone_material_id, stone_material);
 
-        var medium_house = prefab_mgr.loadPrefabFromBinary("prefabs/buildings/medium_house/medium_house.bin", medium_house_id, ecsu_world);
+        var medium_house = prefab_mgr.loadPrefabFromBinary("prefabs/buildings/medium_house/medium_house.bin", medium_house_id, vertex_layout_id, ecsu_world);
         const static_mesh_component = medium_house.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 4;
@@ -174,22 +177,34 @@ pub fn initPrefabs(prefab_mgr: *prefab_manager.PrefabManager, ecsu_world: ecsu.W
     }
 
     {
-        var beech_trunk_04_material = fd.PBRMaterial.init();
+        var beech_trunk_04_material = fd.UberShader.init();
         beech_trunk_04_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_albedo.dds");
         beech_trunk_04_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_arm.dds");
         beech_trunk_04_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_trunk_04_normal.dds");
+        beech_trunk_04_material.wind_feature = true;
+        beech_trunk_04_material.wind_initial_bend = 1.0;
+        beech_trunk_04_material.wind_stifness = 1.0;
+        beech_trunk_04_material.wind_drag = 0.1;
         const beech_trunk_04_material_id = IdLocal.init("M_beech_trunk_04");
         prefab_mgr.storeMaterial(beech_trunk_04_material_id, beech_trunk_04_material);
 
-        var beech_atlas_v2_material = fd.PBRMaterial.init();
+        var beech_atlas_v2_material = fd.UberShader.init();
+        beech_atlas_v2_material.surface_type = .masked;
         beech_atlas_v2_material.albedo = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_v2_albedo.dds");
         beech_atlas_v2_material.arm = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_arm.dds");
         beech_atlas_v2_material.normal = prefab_mgr.rctx.loadTexture("prefabs/environment/beech/beech_atlas_normal.dds");
-        beech_atlas_v2_material.surface_type = .masked;
+        beech_atlas_v2_material.wind_feature = true;
+        beech_atlas_v2_material.wind_initial_bend = 1.0;
+        beech_atlas_v2_material.wind_stifness = 1.0;
+        beech_atlas_v2_material.wind_drag = 0.1;
+        beech_atlas_v2_material.wind_shiver_feature = true;
+        beech_atlas_v2_material.wind_shiver_drag = 0.1;
+        beech_atlas_v2_material.wind_normal_influence = 0.2;
+        beech_atlas_v2_material.wind_shiver_directionality = 0.4;
         const beech_atlas_v2_material_id = IdLocal.init("M_beech_atlas_v2");
         prefab_mgr.storeMaterial(beech_atlas_v2_material_id, beech_atlas_v2_material);
 
-        var beech_tree_04 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/prefab_beech_tree_04_LOD0.bin", beech_tree_04_id, ecsu_world);
+        var beech_tree_04 = prefab_mgr.loadPrefabFromBinary("prefabs/environment/beech/prefab_beech_tree_04_LOD0.bin", beech_tree_04_id, vertex_layout_id, ecsu_world);
         const static_mesh_component = beech_tree_04.getMut(fd.StaticMesh);
         if (static_mesh_component) |static_mesh| {
             static_mesh.material_count = 2;

--- a/src/game.zig
+++ b/src/game.zig
@@ -221,14 +221,6 @@ pub fn run() void {
     const matball_prefab = prefab_mgr.getPrefab(config.prefab.matball_id).?;
     const matball_position = fd.Position.init(player_pos.x, player_pos.y + 100.0, player_pos.z);
     var matball_ent = prefab_mgr.instantiatePrefab(ecsu_world, matball_prefab);
-    const static_mesh_component = matball_ent.getMut(fd.StaticMesh);
-    if (static_mesh_component) |static_mesh| {
-        static_mesh.material_count = 1;
-        static_mesh.materials[0] = fd.PBRMaterial.init();
-        static_mesh.materials[0].albedo = renderer_ctx.loadTexture("textures/debug/round_aluminum_panel_albedo.dds");
-        static_mesh.materials[0].arm = renderer_ctx.loadTexture("textures/debug/round_aluminum_panel_arm.dds");
-        static_mesh.materials[0].normal = renderer_ctx.loadTexture("textures/debug/round_aluminum_panel_normal.dds");
-    }
     matball_ent.set(matball_position);
     matball_ent.set(fd.Rotation{});
     matball_ent.set(fd.Scale.createScalar(1.0));

--- a/src/game.zig
+++ b/src/game.zig
@@ -7,7 +7,7 @@ const zphy = @import("zphysics");
 const zglfw = @import("zglfw");
 const graphics = @import("zforge").graphics;
 const zstbi = @import("zstbi");
-// const ztracy = @import("ztracy");
+const ztracy = @import("ztracy");
 // const AK = @import("wwise-zig");
 // const AK_ID = @import("wwise-ids");
 const audio_manager = @import("audio/audio_manager_mock.zig");
@@ -33,8 +33,8 @@ const world_patch_manager = @import("worldpatch/world_patch_manager.zig");
 // const quality = @import("data/quality.zig");
 
 pub fn run() void {
-    // const tracy_zone = ztracy.ZoneNC(@src(), "Game Run", 0x00_ff_00_00);
-    // defer tracy_zone.End();
+    const tracy_zone = ztracy.ZoneNC(@src(), "Game Run", 0x00_ff_00_00);
+    defer tracy_zone.End();
 
     zstbi.init(std.heap.page_allocator);
     defer zstbi.deinit();
@@ -280,6 +280,9 @@ pub fn run() void {
             gameloop_context,
             &(tl_giant_ant_spawn_ctx.?),
         );
+
+        ztracy.FrameMark();
+
         if (done) {
             break;
         }
@@ -296,8 +299,8 @@ fn update_full(gameloop_context: anytype, tl_giant_ant_spawn_ctx: ?*config.timel
     const renderer_ctx = gameloop_context.renderer;
     var stats = gameloop_context.stats;
 
-    // const trazy_zone = ztracy.ZoneNC(@src(), "Game Loop Update", 0x00_00_00_ff);
-    // defer trazy_zone.End();
+    const trazy_zone = ztracy.ZoneNC(@src(), "Game Loop Update", 0x00_00_00_ff);
+    defer trazy_zone.End();
 
     const window_status = window.update() catch unreachable;
     if (window_status == .no_windows) {

--- a/src/prefab_manager.zig
+++ b/src/prefab_manager.zig
@@ -13,15 +13,18 @@ const IdLocal = @import("core/core.zig").IdLocal;
 const assert = std.debug.assert;
 
 const PrefabHashMap = std.AutoHashMap(IdLocal, ecsu.Entity);
+const MaterialHashmap = std.AutoHashMap(IdLocal, fd.PBRMaterial);
 
 pub const PrefabManager = struct {
     prefab_hash_map: PrefabHashMap,
+    material_hash_map: MaterialHashmap,
     is_a: ecsu.Entity,
     rctx: *renderer.Renderer,
 
     pub fn init(rctx: *renderer.Renderer, world: ecsu.World, allocator: std.mem.Allocator) PrefabManager {
         return PrefabManager{
             .prefab_hash_map = PrefabHashMap.init(allocator),
+            .material_hash_map = MaterialHashmap.init(allocator),
             .is_a = ecsu.Entity.init(world.world, ecs.IsA),
             .rctx = rctx,
         };
@@ -29,6 +32,7 @@ pub const PrefabManager = struct {
 
     pub fn deinit(self: *@This()) void {
         self.prefab_hash_map.deinit();
+        self.material_hash_map.deinit();
     }
 
     pub fn loadPrefabFromBinary(self: *@This(), path: [:0]const u8, id: IdLocal, world: ecsu.World) ecsu.Entity {
@@ -73,6 +77,19 @@ pub const PrefabManager = struct {
         const existing_prefab = self.prefab_hash_map.get(id);
         if (existing_prefab) |prefab| {
             return prefab;
+        }
+
+        return null;
+    }
+
+    pub fn storeMaterial(self: *@This(), id: IdLocal, material: fd.PBRMaterial) void {
+        self.material_hash_map.put(id, material) catch unreachable;
+    }
+
+    pub fn getMaterial(self: *@This(), id: IdLocal) ?fd.PBRMaterial {
+        const existing_material = self.material_hash_map.get(id);
+        if (existing_material) |material| {
+            return material;
         }
 
         return null;

--- a/src/prefab_manager.zig
+++ b/src/prefab_manager.zig
@@ -13,7 +13,7 @@ const IdLocal = @import("core/core.zig").IdLocal;
 const assert = std.debug.assert;
 
 const PrefabHashMap = std.AutoHashMap(IdLocal, ecsu.Entity);
-const MaterialHashmap = std.AutoHashMap(IdLocal, fd.PBRMaterial);
+const MaterialHashmap = std.AutoHashMap(IdLocal, fd.UberShader);
 
 pub const PrefabManager = struct {
     prefab_hash_map: PrefabHashMap,
@@ -35,13 +35,13 @@ pub const PrefabManager = struct {
         self.material_hash_map.deinit();
     }
 
-    pub fn loadPrefabFromBinary(self: *@This(), path: [:0]const u8, id: IdLocal, world: ecsu.World) ecsu.Entity {
+    pub fn loadPrefabFromBinary(self: *@This(), path: [:0]const u8, id: IdLocal, vertex_layout_id: IdLocal, world: ecsu.World) ecsu.Entity {
         const existing_prefab = self.prefab_hash_map.get(id);
         if (existing_prefab) |prefab| {
             return prefab;
         }
 
-        const mesh_handle = self.rctx.loadMesh(path) catch unreachable;
+        const mesh_handle = self.rctx.loadMesh(path, vertex_layout_id) catch unreachable;
         var entity = world.newPrefab(path);
         entity.setOverride(fd.Forward{});
 
@@ -82,11 +82,11 @@ pub const PrefabManager = struct {
         return null;
     }
 
-    pub fn storeMaterial(self: *@This(), id: IdLocal, material: fd.PBRMaterial) void {
+    pub fn storeMaterial(self: *@This(), id: IdLocal, material: fd.UberShader) void {
         self.material_hash_map.put(id, material) catch unreachable;
     }
 
-    pub fn getMaterial(self: *@This(), id: IdLocal) ?fd.PBRMaterial {
+    pub fn getMaterial(self: *@This(), id: IdLocal) ?fd.UberShader {
         const existing_material = self.material_hash_map.get(id);
         if (existing_material) |material| {
             return material;

--- a/src/prefab_manager.zig
+++ b/src/prefab_manager.zig
@@ -3,6 +3,7 @@ const ecs = @import("zflecs");
 const ecsu = @import("flecs_util/flecs_util.zig");
 const zm = @import("zmath");
 const zmesh = @import("zmesh");
+const ztracy = @import("ztracy");
 const zwin32 = @import("zwin32");
 
 const fd = @import("config/flecs_data.zig");
@@ -87,6 +88,9 @@ pub const PrefabManager = struct {
     }
 
     pub fn getMaterial(self: *@This(), id: IdLocal) ?fd.UberShader {
+        const trazy_zone = ztracy.ZoneNC(@src(), "Get Material", 0x00_ff_ff_00);
+        defer trazy_zone.End();
+
         const existing_material = self.material_hash_map.get(id);
         if (existing_material) |material| {
             return material;

--- a/src/renderer/renderer.zig
+++ b/src/renderer/renderer.zig
@@ -207,8 +207,8 @@ pub const Renderer = struct {
         self.im3d_vertex_layout.mAttribs[1].mOffset = @sizeOf(f32) * 4;
 
         self.default_vertex_layout = std.mem.zeroes(graphics.VertexLayout);
-        self.default_vertex_layout.mBindingCount = 4;
-        self.default_vertex_layout.mAttribCount = 4;
+        self.default_vertex_layout.mBindingCount = 5;
+        self.default_vertex_layout.mAttribCount = 5;
         self.default_vertex_layout.mAttribs[0].mSemantic = graphics.ShaderSemantic.POSITION;
         self.default_vertex_layout.mAttribs[0].mFormat = graphics.TinyImageFormat.R32G32B32_SFLOAT;
         self.default_vertex_layout.mAttribs[0].mBinding = 0;
@@ -229,6 +229,11 @@ pub const Renderer = struct {
         self.default_vertex_layout.mAttribs[3].mBinding = 3;
         self.default_vertex_layout.mAttribs[3].mLocation = 3;
         self.default_vertex_layout.mAttribs[3].mOffset = 0;
+        self.default_vertex_layout.mAttribs[4].mSemantic = graphics.ShaderSemantic.COLOR;
+        self.default_vertex_layout.mAttribs[4].mFormat = graphics.TinyImageFormat.R8G8B8A8_UNORM;
+        self.default_vertex_layout.mAttribs[4].mBinding = 4;
+        self.default_vertex_layout.mAttribs[4].mLocation = 4;
+        self.default_vertex_layout.mAttribs[4].mOffset = 0;
 
         self.frame_index = 0;
 
@@ -657,11 +662,13 @@ pub const Renderer = struct {
         mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)] = 1;
         mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)] = 2;
         mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)] = 3;
+        mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)] = 4;
 
         mesh.buffer_layout_desc.mVerticesStrides[0] = @sizeOf(f32) * 3;
         mesh.buffer_layout_desc.mVerticesStrides[1] = @sizeOf(u32);
         mesh.buffer_layout_desc.mVerticesStrides[2] = @sizeOf(u32);
         mesh.buffer_layout_desc.mVerticesStrides[3] = @sizeOf(u32);
+        mesh.buffer_layout_desc.mVerticesStrides[4] = @sizeOf(u32);
 
         const index_count_max: u32 = 1024 * 1024;
         const vertex_count_max: u32 = 1024 * 1024;
@@ -673,11 +680,13 @@ pub const Renderer = struct {
         buffer_load_desc.mVerticesSizes[1] = mesh.buffer_layout_desc.mVerticesStrides[1] * vertex_count_max;
         buffer_load_desc.mVerticesSizes[2] = mesh.buffer_layout_desc.mVerticesStrides[2] * vertex_count_max;
         buffer_load_desc.mVerticesSizes[3] = mesh.buffer_layout_desc.mVerticesStrides[3] * vertex_count_max;
+        buffer_load_desc.mVerticesSizes[4] = mesh.buffer_layout_desc.mVerticesStrides[4] * vertex_count_max;
         buffer_load_desc.pNameIndexBuffer = "Indices";
         buffer_load_desc.pNamesVertexBuffers[0] = "Positions";
         buffer_load_desc.pNamesVertexBuffers[1] = "Normals";
         buffer_load_desc.pNamesVertexBuffers[2] = "Tangents";
         buffer_load_desc.pNamesVertexBuffers[3] = "UVs";
+        buffer_load_desc.pNamesVertexBuffers[4] = "Colors";
         resource_loader.addGeometryBuffer(&buffer_load_desc);
 
         var load_desc = std.mem.zeroes(resource_loader.GeometryLoadDesc);

--- a/src/renderer/renderer.zig
+++ b/src/renderer/renderer.zig
@@ -12,6 +12,7 @@ const log = zforge.log;
 const memory = zforge.memory;
 const resource_loader = zforge.resource_loader;
 const util = @import("../util.zig");
+const ztracy = @import("ztracy");
 
 const Pool = @import("zpool").Pool;
 
@@ -543,6 +544,9 @@ pub const Renderer = struct {
     }
 
     pub fn draw(self: *Renderer) void {
+        const trazy_zone = ztracy.ZoneNC(@src(), "Render", 0x00_ff_ff_00);
+        defer trazy_zone.End();
+
         var swap_chain_image_index: u32 = 0;
         graphics.acquireNextImage(self.renderer, self.swap_chain, self.image_acquired_semaphore, null, &swap_chain_image_index);
 

--- a/src/renderer/renderer.zig
+++ b/src/renderer/renderer.zig
@@ -1842,7 +1842,7 @@ pub const Renderer = struct {
             pipeline_desc.__union_field1.mGraphicsDesc.mSampleQuality = 0;
             pipeline_desc.__union_field1.mGraphicsDesc.pRootSignature = root_signature;
             pipeline_desc.__union_field1.mGraphicsDesc.pShaderProgram = shader;
-            pipeline_desc.__union_field1.mGraphicsDesc.pVertexLayout = @ptrCast(&imgui_vertex_layout);
+            pipeline_desc.__union_field1.mGraphicsDesc.pVertexLayout = @constCast(&imgui_vertex_layout);
             pipeline_desc.__union_field1.mGraphicsDesc.pRasterizerState = &rasterizer_state_desc;
             pipeline_desc.__union_field1.mGraphicsDesc.pBlendState = &blend_state_desc;
             graphics.addPipeline(self.renderer, &pipeline_desc, @ptrCast(&pipeline));

--- a/src/renderer/renderer.zig
+++ b/src/renderer/renderer.zig
@@ -24,6 +24,20 @@ pub const renderPassCreateDescriptorSetsFn = ?*const fn (user_data: *anyopaque) 
 pub const renderPassPrepareDescriptorSetsFn = ?*const fn (user_data: *anyopaque) void;
 pub const renderPassUnloadDescriptorSetsFn = ?*const fn (user_data: *anyopaque) void;
 
+pub const opaque_pipelines = [_]IdLocal{
+    IdLocal.init("lit"),
+    IdLocal.init("shadows_lit"),
+    IdLocal.init("tree"),
+    IdLocal.init("shadows_tree"),
+};
+
+pub const masked_pipelines = [_]IdLocal{
+    IdLocal.init("lit_masked"),
+    IdLocal.init("shadows_lit_masked"),
+    IdLocal.init("tree_masked"),
+    IdLocal.init("shadows_tree_masked"),
+};
+
 const VertexLayoutHashMap = std.AutoHashMap(IdLocal, graphics.VertexLayout);
 
 pub const Renderer = struct {
@@ -34,6 +48,7 @@ pub const Renderer = struct {
     window: *window.Window = undefined,
     window_width: i32 = 0,
     window_height: i32 = 0,
+    time: f32 = 0.0,
 
     swap_chain: [*c]graphics.SwapChain = null,
     gpu_cmd_ring: graphics.GpuCmdRing = undefined,
@@ -119,6 +134,7 @@ pub const Renderer = struct {
         self.window = wnd;
         self.window_width = wnd.frame_buffer_size[0];
         self.window_height = wnd.frame_buffer_size[1];
+        self.time = 0.0;
 
         // Initialize The-Forge systems
         if (!memory.initMemAlloc("Tides Renderer")) {
@@ -976,6 +992,10 @@ pub const Renderer = struct {
         const handle = self.pso_map.get(id).?;
         const root_signature = self.pso_pool.getColumn(handle, .root_signature) catch unreachable;
         return root_signature;
+    }
+
+    pub fn getVertexLayout(self: *Renderer, id: IdLocal) ?graphics.VertexLayout {
+        return self.vertex_layouts_map.get(id);
     }
 
     fn addSwapchain(self: *Renderer) bool {

--- a/src/shaders/HLSL/lit.vert.hlsl
+++ b/src/shaders/HLSL/lit.vert.hlsl
@@ -1,6 +1,7 @@
 #define DIRECT3D12
 #define STAGE_VERT
 
+#define VL_PosNorTanUv0Col
 #include "lit_resources.hlsl"
 
 VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)

--- a/src/shaders/HLSL/lit.vert.hlsl
+++ b/src/shaders/HLSL/lit.vert.hlsl
@@ -7,6 +7,7 @@ VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)
 {
     INIT_MAIN;
     VSOutput Out;
+    Out.Color = Input.Color;
     Out.InstanceID = instance_id;
     Out.UV = unpack2Floats(Input.UV);
 

--- a/src/shaders/HLSL/lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/lit_masked.frag.hlsl
@@ -24,6 +24,8 @@ GBufferOutput PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
         float4 baseColorSample = baseColorTexture.Sample(Get(bilinearRepeatSampler), Input.UV);
         clip(baseColorSample.a - 0.5);
         baseColor *= baseColorSample.rgb;
+    } else {
+        baseColor *= Input.Color.rgb;
     }
 
     float3 N = normalize(Input.Normal);
@@ -32,9 +34,9 @@ GBufferOutput PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
         N = UnpackNormals(Input.UV, -V, normalTexture, Get(bilinearRepeatSampler), Input.Normal, 1.0f);
     }
 
-    if (isFrontFace) {
-        N *= -1.0;
-    }
+    // if (isFrontFace) {
+    //     N *= -1.0;
+    // }
 
     float roughness = material.roughness;
     float metallic = material.metallic;

--- a/src/shaders/HLSL/lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/lit_masked.frag.hlsl
@@ -13,7 +13,7 @@ GBufferOutput PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
     InstanceData instance = instanceTransformsBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
     ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
+    MaterialData material = materialsBuffer.Load<MaterialData>(instance.materialBufferOffset);
 
     const float3 P = Input.PositionWS.xyz;
     const float3 V = normalize(Get(camPos).xyz - P);

--- a/src/shaders/HLSL/lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/lit_masked.frag.hlsl
@@ -13,7 +13,7 @@ GBufferOutput PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
     InstanceData instance = instanceTransformsBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
     ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instanceIndex * sizeof(InstanceMaterial));
+    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
 
     const float3 P = Input.PositionWS.xyz;
     const float3 V = normalize(Get(camPos).xyz - P);

--- a/src/shaders/HLSL/lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/lit_masked.frag.hlsl
@@ -1,6 +1,7 @@
 #define DIRECT3D12
 #define STAGE_FRAG
 
+#define VL_PosNorTanUv0Col
 #include "lit_resources.hlsl"
 #include "utils.hlsl"
 

--- a/src/shaders/HLSL/lit_opaque.frag.hlsl
+++ b/src/shaders/HLSL/lit_opaque.frag.hlsl
@@ -23,6 +23,8 @@ GBufferOutput PS_MAIN( VSOutput Input) {
         Texture2D baseColorTexture = ResourceDescriptorHeap[NonUniformResourceIndex(material.baseColorTextureIndex)];
         float4 baseColorSample = baseColorTexture.Sample(Get(bilinearRepeatSampler), Input.UV);
         baseColor *= baseColorSample.rgb;
+    } else {
+        baseColor *= Input.Color.rgb;
     }
 
     float3 N = normalize(Input.Normal);

--- a/src/shaders/HLSL/lit_opaque.frag.hlsl
+++ b/src/shaders/HLSL/lit_opaque.frag.hlsl
@@ -12,8 +12,8 @@ GBufferOutput PS_MAIN( VSOutput Input) {
     uint instanceIndex = Input.InstanceID + Get(startInstanceLocation);
     InstanceData instance = instanceTransformBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
-    ByteAddressBuffer materialBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialBuffer.Load<InstanceMaterial>(instanceIndex * sizeof(InstanceMaterial));
+    ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
+    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
 
     const float3 P = Input.PositionWS.xyz;
     const float3 V = normalize(Get(camPos).xyz - P);

--- a/src/shaders/HLSL/lit_opaque.frag.hlsl
+++ b/src/shaders/HLSL/lit_opaque.frag.hlsl
@@ -13,7 +13,7 @@ GBufferOutput PS_MAIN( VSOutput Input) {
     InstanceData instance = instanceTransformBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
     ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
+    MaterialData material = materialsBuffer.Load<MaterialData>(instance.materialBufferOffset);
 
     const float3 P = Input.PositionWS.xyz;
     const float3 V = normalize(Get(camPos).xyz - P);

--- a/src/shaders/HLSL/lit_resources.hlsl
+++ b/src/shaders/HLSL/lit_resources.hlsl
@@ -54,6 +54,7 @@ STRUCT(VSInput)
 	DATA(uint, Normal, NORMAL);
 	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
 };
 
 STRUCT(VSOutput)
@@ -63,6 +64,7 @@ STRUCT(VSOutput)
 	DATA(float3, Normal, NORMAL);
 	DATA(float3, Tangent, TANGENT);
 	DATA(float2, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
 	DATA(uint, InstanceID, SV_InstanceID);
 };
 

--- a/src/shaders/HLSL/lit_resources.hlsl
+++ b/src/shaders/HLSL/lit_resources.hlsl
@@ -8,6 +8,7 @@ struct InstanceData
 {
 	float4x4 worldMat;
 	uint materialBufferOffset;
+	float3 _padding;
 };
 
 struct InstanceMaterial

--- a/src/shaders/HLSL/lit_resources.hlsl
+++ b/src/shaders/HLSL/lit_resources.hlsl
@@ -3,6 +3,7 @@
 
 #include "../FSL/d3d.h"
 #include "../FSL/ShaderUtilities.h.fsl"
+#include "material.hlsl"
 
 struct InstanceData
 {
@@ -10,26 +11,6 @@ struct InstanceData
 	uint materialBufferOffset;
 	float3 _padding;
 };
-
-struct InstanceMaterial
-{
-	float4 baseColor;
-	float roughness;
-	float metallic;
-	float normalIntensity;
-	float emissiveStrength;
-	uint baseColorTextureIndex;
-	uint emissiveTextureIndex;
-	uint normalTextureIndex;
-	uint armTextureIndex;
-};
-
-static const uint INVALID_TEXTURE_INDEX = 0xFFFFFFFF;
-
-bool hasValidTexture(uint textureIndex)
-{
-	return textureIndex != INVALID_TEXTURE_INDEX;
-}
 
 RES(SamplerState, bilinearRepeatSampler, UPDATE_FREQ_NONE, s0, binding = 1);
 RES(SamplerState, bilinearClampSampler, UPDATE_FREQ_NONE, s1, binding = 2);

--- a/src/shaders/HLSL/lit_resources.hlsl
+++ b/src/shaders/HLSL/lit_resources.hlsl
@@ -7,6 +7,7 @@
 struct InstanceData
 {
 	float4x4 worldMat;
+	uint materialBufferOffset;
 };
 
 struct InstanceMaterial

--- a/src/shaders/HLSL/lit_resources.hlsl
+++ b/src/shaders/HLSL/lit_resources.hlsl
@@ -8,6 +8,7 @@
 struct InstanceData
 {
 	float4x4 worldMat;
+	float4x4 worldMatInverted;
 	uint materialBufferOffset;
 	float3 _padding;
 };
@@ -20,6 +21,7 @@ CBUFFER(cbFrame, UPDATE_FREQ_PER_FRAME, b1, binding = 0)
 	DATA(float4x4, projView, None);
 	DATA(float4x4, projViewInverted, None);
 	DATA(float4, camPos, None);
+	DATA(float, time, None);
 };
 
 PUSH_CONSTANT(RootConstant, b0)
@@ -28,6 +30,8 @@ PUSH_CONSTANT(RootConstant, b0)
 	DATA(uint, instanceDataBufferIndex, None);
 	DATA(uint, materialBufferIndex, None);
 };
+
+#if defined(VL_PosNorTanUv0Col)
 
 STRUCT(VSInput)
 {
@@ -49,13 +53,37 @@ STRUCT(VSOutput)
 	DATA(uint, InstanceID, SV_InstanceID);
 };
 
+#elif defined(VL_PosNorTanUv0ColUv1)
+
+STRUCT(VSInput)
+{
+	DATA(float4, Position, POSITION);
+	DATA(uint, Normal, NORMAL);
+	DATA(uint, Tangent, TANGENT);
+	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
+	DATA(float2, UV1, TEXCOORD1);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, PositionWS, POSITION);
+	DATA(float3, Normal, NORMAL);
+	DATA(float3, Tangent, TANGENT);
+	DATA(float2, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
+	DATA(float2, UV1, TEXCOORD1);
+	DATA(uint, InstanceID, SV_InstanceID);
+};
+
+#endif
+
 STRUCT(GBufferOutput)
 {
 	DATA(float4, GBuffer0, SV_TARGET0);
 	DATA(float4, GBuffer1, SV_TARGET1);
 	DATA(float4, GBuffer2, SV_TARGET2);
 };
-
-// #include "pbr.h"
 
 #endif // _LIT_RESOURCES_H

--- a/src/shaders/HLSL/material.hlsl
+++ b/src/shaders/HLSL/material.hlsl
@@ -1,0 +1,32 @@
+#ifndef _MATERIAL_H
+#define _MATERIAL_H
+
+struct MaterialData
+{
+	float4 baseColor;
+	float roughness;
+	float metallic;
+	float normalIntensity;
+	float emissiveStrength;
+	uint baseColorTextureIndex;
+	uint emissiveTextureIndex;
+	uint normalTextureIndex;
+	uint armTextureIndex;
+    bool wind_feature;
+    float wind_initial_bend;
+    float wind_stifness;
+    float wind_drag;
+    bool wind_shiver_feature;
+    float wind_shiver_drag;
+    float wind_normal_influence;
+    float wind_shiver_directionality;
+};
+
+static const uint INVALID_TEXTURE_INDEX = 0xFFFFFFFF;
+
+bool hasValidTexture(uint textureIndex)
+{
+	return textureIndex != INVALID_TEXTURE_INDEX;
+}
+
+#endif // _MATERIAL_H

--- a/src/shaders/HLSL/material.hlsl
+++ b/src/shaders/HLSL/material.hlsl
@@ -12,14 +12,14 @@ struct MaterialData
 	uint emissiveTextureIndex;
 	uint normalTextureIndex;
 	uint armTextureIndex;
-    bool wind_feature;
-    float wind_initial_bend;
-    float wind_stifness;
-    float wind_drag;
-    bool wind_shiver_feature;
-    float wind_shiver_drag;
-    float wind_normal_influence;
-    float wind_shiver_directionality;
+    uint windFeature;
+    float windInitialBend;
+    float windStifness;
+    float windDrag;
+    uint windShiverFeature;
+    float windShiverDrag;
+    float windNormalInfluence;
+    float windShiverDirectionality;
 };
 
 static const uint INVALID_TEXTURE_INDEX = 0xFFFFFFFF;

--- a/src/shaders/HLSL/shadows_lit.vert.hlsl
+++ b/src/shaders/HLSL/shadows_lit.vert.hlsl
@@ -1,6 +1,7 @@
 #define DIRECT3D12
 #define STAGE_VERT
 
+#define VL_PosNorTanUv0Col
 #include "shadows_lit_resources.hlsl"
 
 VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)

--- a/src/shaders/HLSL/shadows_lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/shadows_lit_masked.frag.hlsl
@@ -12,7 +12,7 @@ void PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
     InstanceData instance = instanceTransformsBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
     ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instanceIndex * sizeof(InstanceMaterial));
+    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
 
     if (hasValidTexture(material.baseColorTextureIndex)) {
         Texture2D baseColorTexture = ResourceDescriptorHeap[NonUniformResourceIndex(material.baseColorTextureIndex)];

--- a/src/shaders/HLSL/shadows_lit_masked.frag.hlsl
+++ b/src/shaders/HLSL/shadows_lit_masked.frag.hlsl
@@ -12,7 +12,7 @@ void PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
     InstanceData instance = instanceTransformsBuffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
 
     ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
-    InstanceMaterial material = materialsBuffer.Load<InstanceMaterial>(instance.materialBufferOffset);
+    MaterialData material = materialsBuffer.Load<MaterialData>(instance.materialBufferOffset);
 
     if (hasValidTexture(material.baseColorTextureIndex)) {
         Texture2D baseColorTexture = ResourceDescriptorHeap[NonUniformResourceIndex(material.baseColorTextureIndex)];

--- a/src/shaders/HLSL/shadows_lit_resources.hlsl
+++ b/src/shaders/HLSL/shadows_lit_resources.hlsl
@@ -8,6 +8,7 @@ struct InstanceData
 {
 	float4x4 worldMat;
 	uint materialBufferOffset;
+	float3 _padding;
 };
 
 struct InstanceMaterial

--- a/src/shaders/HLSL/shadows_lit_resources.hlsl
+++ b/src/shaders/HLSL/shadows_lit_resources.hlsl
@@ -3,6 +3,7 @@
 
 #include "../FSL/d3d.h"
 #include "../FSL/ShaderUtilities.h.fsl"
+#include "material.hlsl"
 
 struct InstanceData
 {
@@ -10,26 +11,6 @@ struct InstanceData
 	uint materialBufferOffset;
 	float3 _padding;
 };
-
-struct InstanceMaterial
-{
-	float4 baseColor;
-	float roughness;
-	float metallic;
-	float normalIntensity;
-	float emissiveStrength;
-	uint baseColorTextureIndex;
-	uint emissiveTextureIndex;
-	uint normalTextureIndex;
-	uint armTextureIndex;
-};
-
-static const uint INVALID_TEXTURE_INDEX = 0xFFFFFFFF;
-
-bool hasValidTexture(uint textureIndex)
-{
-	return textureIndex != INVALID_TEXTURE_INDEX;
-}
 
 RES(SamplerState, bilinearRepeatSampler, UPDATE_FREQ_NONE, s0, binding = 1);
 RES(SamplerState, bilinearClampSampler, UPDATE_FREQ_NONE, s1, binding = 2);

--- a/src/shaders/HLSL/shadows_lit_resources.hlsl
+++ b/src/shaders/HLSL/shadows_lit_resources.hlsl
@@ -8,6 +8,7 @@
 struct InstanceData
 {
 	float4x4 worldMat;
+	float4x4 worldMatInverted;
 	uint materialBufferOffset;
 	float3 _padding;
 };
@@ -18,6 +19,7 @@ RES(SamplerState, bilinearClampSampler, UPDATE_FREQ_NONE, s1, binding = 2);
 CBUFFER(cbFrame, UPDATE_FREQ_PER_FRAME, b1, binding = 0)
 {
 	DATA(float4x4, projView, None);
+	DATA(float, time, None);
 };
 
 PUSH_CONSTANT(RootConstant, b0)
@@ -26,6 +28,8 @@ PUSH_CONSTANT(RootConstant, b0)
 	DATA(uint, instanceDataBufferIndex, None);
 	DATA(uint, materialBufferIndex, None);
 };
+
+#if defined(VL_PosNorTanUv0Col)
 
 STRUCT(VSInput)
 {
@@ -42,5 +46,27 @@ STRUCT(VSOutput)
 	DATA(float2, UV, TEXCOORD0);
 	DATA(uint, InstanceID, SV_InstanceID);
 };
+
+#elif defined(VL_PosNorTanUv0ColUv1)
+
+STRUCT(VSInput)
+{
+	DATA(float4, Position, POSITION);
+	DATA(uint, Normal, NORMAL);
+	DATA(uint, Tangent, TANGENT);
+	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
+	DATA(float2, UV1, TEXCOORD1);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float2, UV, TEXCOORD0);
+	DATA(float2, UV1, TEXCOORD1);
+	DATA(uint, InstanceID, SV_InstanceID);
+};
+
+#endif
 
 #endif // _SHADOWS_LIT_RESOURCES_H

--- a/src/shaders/HLSL/shadows_lit_resources.hlsl
+++ b/src/shaders/HLSL/shadows_lit_resources.hlsl
@@ -7,6 +7,7 @@
 struct InstanceData
 {
 	float4x4 worldMat;
+	uint materialBufferOffset;
 };
 
 struct InstanceMaterial

--- a/src/shaders/HLSL/shadows_lit_resources.hlsl
+++ b/src/shaders/HLSL/shadows_lit_resources.hlsl
@@ -52,6 +52,7 @@ STRUCT(VSInput)
 	DATA(uint, Normal, NORMAL);
 	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
 };
 
 STRUCT(VSOutput)

--- a/src/shaders/HLSL/shadows_terrain_resources.hlsl
+++ b/src/shaders/HLSL/shadows_terrain_resources.hlsl
@@ -34,6 +34,7 @@ STRUCT(VSInput)
 	DATA(uint, Normal, NORMAL);
 	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
 };
 
 STRUCT(VSOutput)

--- a/src/shaders/HLSL/shadows_terrain_resources.hlsl
+++ b/src/shaders/HLSL/shadows_terrain_resources.hlsl
@@ -31,8 +31,6 @@ PUSH_CONSTANT(RootConstant, b0)
 STRUCT(VSInput)
 {
 	DATA(float4, Position, POSITION);
-	DATA(uint, Normal, NORMAL);
-	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
 	DATA(float4, Color, COLOR);
 };

--- a/src/shaders/HLSL/shadows_tree.vert.hlsl
+++ b/src/shaders/HLSL/shadows_tree.vert.hlsl
@@ -1,0 +1,39 @@
+#define DIRECT3D12
+#define STAGE_VERT
+
+#define VL_PosNorTanUv0ColUV1
+#include "shadows_tree_resources.hlsl"
+
+VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    Out.InstanceID = instance_id;
+    Out.UV = unpack2Floats(Input.UV);
+    Out.UV1 = Input.UV1;
+
+    ByteAddressBuffer instance_transform_buffer = ResourceDescriptorHeap[Get(instanceDataBufferIndex)];
+    uint instanceIndex = instance_id + Get(startInstanceLocation);
+    InstanceData instance = instance_transform_buffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
+
+    ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
+    MaterialData material = materialsBuffer.Load<MaterialData>(instance.materialBufferOffset);
+
+    float3 positionOS = Input.Position.xyz;
+    float3 positionWS = mul(instance.worldMat, float4(positionOS, 1.0f)).xyz;
+    float3 normalWS = mul(instance.worldMat, float4(decodeDir(unpackUnorm2x16(Input.Normal)), 0.0f)).xyz;
+
+    if (material.windFeature) {
+        // Wind
+        float3 rootWP = mul(instance.worldMat, float4(0, 0, 0, 1)).xyz;
+
+        WindData windData;
+        ApplyWindDisplacement(positionWS, windData, normalWS, rootWP, material.windStifness, material.windDrag, material.windInitialBend, Get(time));
+        positionOS = mul(instance.worldMatInverted, float4(positionWS, 1.0f)).xyz;
+    }
+
+    float4x4 mvp = mul(Get(projView), instance.worldMat);
+    Out.Position = mul(mvp, float4(positionOS, 1.0f));
+
+    RETURN(Out);
+}

--- a/src/shaders/HLSL/shadows_tree_masked.frag.hlsl
+++ b/src/shaders/HLSL/shadows_tree_masked.frag.hlsl
@@ -1,11 +1,11 @@
 #define DIRECT3D12
 #define STAGE_FRAG
 
-#define VL_PosNorTanUv0Col
-#include "shadows_lit_resources.hlsl"
+#define VL_PosNorTanUv0ColUV1
+#include "shadows_tree_resources.hlsl"
 #include "utils.hlsl"
 
-void PS_MAIN( VSOutput Input, bool isFrontFace : SV_IsFrontFace ) {
+void PS_MAIN( VSOutput Input) {
     INIT_MAIN;
 
     ByteAddressBuffer instanceTransformsBuffer = ResourceDescriptorHeap[Get(instanceDataBufferIndex)];

--- a/src/shaders/HLSL/shadows_tree_opaque.frag.hlsl
+++ b/src/shaders/HLSL/shadows_tree_opaque.frag.hlsl
@@ -1,8 +1,8 @@
 #define DIRECT3D12
 #define STAGE_FRAG
 
-#define VL_PosNorTanUv0Col
-#include "shadows_lit_resources.hlsl"
+#define VL_PosNorTanUv0ColUV1
+#include "shadows_tree_resources.hlsl"
 #include "utils.hlsl"
 
 void PS_MAIN( VSOutput Input) {

--- a/src/shaders/HLSL/shadows_tree_resources.hlsl
+++ b/src/shaders/HLSL/shadows_tree_resources.hlsl
@@ -1,0 +1,11 @@
+#ifndef _SHADOWS_TREE_RESOURCES_H
+#define _SHADOWS_TREE_RESOURCES_H
+
+#define VL_PosNorTanUv0ColUv1
+#include "shadows_lit_resources.hlsl"
+
+#define WIND_CBUFFER_REG b2
+#define WIND_CBUFFER_BINDING 3
+#include "wind.hlsl"
+
+#endif // _SHADOWS_TREE_RESOURCES_H

--- a/src/shaders/HLSL/terrain.vert.hlsl
+++ b/src/shaders/HLSL/terrain.vert.hlsl
@@ -23,9 +23,6 @@ VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)
     float4x4 tempMat = mul(Get(projView), instance.worldMat);
     Out.Position = mul(tempMat, float4(displaced_position, 1.0f));
     Out.PositionWS = mul(instance.worldMat, float4(displaced_position, 1.0f)).xyz;
-    // TODO(gmodarelli): We don't need to store normals and tangent in the vertex buffer since terrain tiles are flat
-    Out.Normal = mul(instance.worldMat, float4(decodeDir(unpackUnorm2x16(Input.Normal)), 0.0f)).rgb;
-    Out.Tangent = mul(instance.worldMat, float4(decodeDir(unpackUnorm2x16(Input.Tangent)), 0.0f)).rgb;
 
     RETURN(Out);
 }

--- a/src/shaders/HLSL/terrain_resources.hlsl
+++ b/src/shaders/HLSL/terrain_resources.hlsl
@@ -44,6 +44,7 @@ STRUCT(VSInput)
 	DATA(uint, Normal, NORMAL);
 	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
+	DATA(float4, Color, COLOR);
 };
 
 STRUCT(VSOutput)

--- a/src/shaders/HLSL/terrain_resources.hlsl
+++ b/src/shaders/HLSL/terrain_resources.hlsl
@@ -41,8 +41,6 @@ PUSH_CONSTANT(RootConstant, b0)
 STRUCT(VSInput)
 {
 	DATA(float4, Position, POSITION);
-	DATA(uint, Normal, NORMAL);
-	DATA(uint, Tangent, TANGENT);
 	DATA(uint, UV, TEXCOORD0);
 	DATA(float4, Color, COLOR);
 };
@@ -51,8 +49,6 @@ STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
 	DATA(float3, PositionWS, POSITION);
-	DATA(float3, Normal, NORMAL);
-	DATA(float3, Tangent, TANGENT);
 	DATA(float2, UV, TEXCOORD0);
 	DATA(uint, InstanceID, SV_InstanceID);
 };

--- a/src/shaders/HLSL/tree.vert.hlsl
+++ b/src/shaders/HLSL/tree.vert.hlsl
@@ -1,0 +1,43 @@
+#define DIRECT3D12
+#define STAGE_VERT
+
+#define VL_PosNorTanUv0ColUV1
+#include "tree_resources.hlsl"
+
+VSOutput VS_MAIN(VSInput Input, uint instance_id : SV_InstanceID)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    Out.Color = Input.Color;
+    Out.InstanceID = instance_id;
+    Out.UV = unpack2Floats(Input.UV);
+    Out.UV1 = Input.UV1;
+
+    ByteAddressBuffer instance_transform_buffer = ResourceDescriptorHeap[Get(instanceDataBufferIndex)];
+    uint instanceIndex = instance_id + Get(startInstanceLocation);
+    InstanceData instance = instance_transform_buffer.Load<InstanceData>(instanceIndex * sizeof(InstanceData));
+
+    ByteAddressBuffer materialsBuffer = ResourceDescriptorHeap[Get(materialBufferIndex)];
+    MaterialData material = materialsBuffer.Load<MaterialData>(instance.materialBufferOffset);
+
+    float3 positionOS = Input.Position.xyz;
+    float3 positionWS = mul(instance.worldMat, float4(positionOS, 1.0f)).xyz;
+    float3 normalWS = mul(instance.worldMat, float4(decodeDir(unpackUnorm2x16(Input.Normal)), 0.0f)).xyz;
+
+    if (material.windFeature) {
+        // Wind
+        float3 rootWP = mul(instance.worldMat, float4(0, 0, 0, 1)).xyz;
+
+        WindData windData;
+        ApplyWindDisplacement(positionWS, windData, normalWS, rootWP, material.windStifness, material.windDrag, material.windInitialBend, Get(time));
+        positionOS = mul(instance.worldMatInverted, float4(positionWS, 1.0f)).xyz;
+    }
+
+    float4x4 mvp = mul(Get(projView), instance.worldMat);
+    Out.Position = mul(mvp, float4(positionOS, 1.0f));
+    Out.PositionWS = positionWS;
+    Out.Normal = normalWS;
+    Out.Tangent = mul(instance.worldMat, float4(decodeDir(unpackUnorm2x16(Input.Tangent)), 0.0f)).rgb;
+
+    RETURN(Out);
+}

--- a/src/shaders/HLSL/tree_opaque.frag.hlsl
+++ b/src/shaders/HLSL/tree_opaque.frag.hlsl
@@ -1,8 +1,8 @@
 #define DIRECT3D12
 #define STAGE_FRAG
 
-#define VL_PosNorTanUv0Col
-#include "lit_resources.hlsl"
+#define VL_PosNorTanUv0ColUV1
+#include "tree_resources.hlsl"
 #include "utils.hlsl"
 
 GBufferOutput PS_MAIN( VSOutput Input) {

--- a/src/shaders/HLSL/tree_resources.hlsl
+++ b/src/shaders/HLSL/tree_resources.hlsl
@@ -1,0 +1,11 @@
+#ifndef _TREE_RESOURCES_H
+#define _TREE_RESOURCES_H
+
+#define VL_PosNorTanUv0ColUv1
+#include "lit_resources.hlsl"
+
+#define WIND_CBUFFER_REG b2
+#define WIND_CBUFFER_BINDING 3
+#include "wind.hlsl"
+
+#endif // _TREE_RESOURCES_H

--- a/src/shaders/HLSL/wind.hlsl
+++ b/src/shaders/HLSL/wind.hlsl
@@ -1,0 +1,116 @@
+#ifndef _WIND_H
+#define _WIND_H
+
+#ifndef WIND_CBUFFER_REG
+#define WIND_CBUFFER_REG b2
+#endif
+
+#ifndef WIND_CBUFFER_BINDING
+#define WIND_CBUFFER_BINDING 1
+#endif
+
+#define FLT_EPSILON 1.192092896e-07
+
+CBUFFER(cbWind, UPDATE_FREQ_PER_FRAME, WIND_CBUFFER_REG, binding = WIND_CBUFFER_BINDING)
+{
+	DATA(float4, windWorldDirectionAndSpeed, None);
+	DATA(float, windFlexNoiseScale, None);
+	DATA(float, windTurbulence, None);
+	DATA(float, windGustSpeed, None);
+	DATA(float, windGustScale, None);
+	DATA(float, windGustWorldScale, None);
+    DATA(uint, windNoiseTextureIndex, None);
+    DATA(uint, windGustTextureIndex, None);
+};
+
+float PositivePow(float base, float power)
+{
+    return pow(max(abs(base), float(FLT_EPSILON)), power);
+}
+
+float AttenuateTrunk(float x, float s)
+{
+    float r = (x / s);
+    return PositivePow(r, 1 / s);
+}
+
+float3 Rotate(float3 pivot, float3 position, float3 rotationAxis, float angle)
+{
+    rotationAxis = normalize(rotationAxis);
+    float3 cpa = pivot + rotationAxis * dot(rotationAxis, position - pivot);
+    return cpa + ((position - cpa) * cos(angle) + cross(rotationAxis, (position - cpa)) * sin(angle));
+}
+
+struct WindData
+{
+    float3 Direction;
+    float Strength;
+    float3 Gust;
+};
+
+float3 texNoise(float3 worldPos, float LOD)
+{
+    Texture2D noiseMap = ResourceDescriptorHeap[Get(windNoiseTextureIndex)];
+    return SampleLvlTex2D(noiseMap, Get(bilinearRepeatSampler), worldPos.xz, LOD).xyz - 0.5;
+}
+
+float texGust(float3 worldPos, float LOD)
+{
+    Texture2D gustMap = ResourceDescriptorHeap[Get(windGustTextureIndex)];
+    return SampleLvlTex2D(gustMap, Get(bilinearRepeatSampler), worldPos.xz, LOD).x;
+}
+
+WindData GetAnalyticalWind(float3 worldPosition, float3 pivotPosition, float drag, float initialBend, float time)
+{
+    WindData result;
+
+    float3 normalizedDir = normalize(Get(windWorldDirectionAndSpeed).xyz);
+    float3 worldOffset = float3(1, 0, 0) * Get(windWorldDirectionAndSpeed).w * time;
+    float3 gustWorldOffset = float3(1, 0, 0) * Get(windGustSpeed) * time;
+
+    // Trunk noise is base wind + gusts + noise
+    float3 trunk = float3(0, 0, 0);
+    if (Get(windWorldDirectionAndSpeed).w > 0.0 || Get(windTurbulence) > 0.0)
+    {
+        trunk = texNoise((pivotPosition - worldOffset) * Get(windFlexNoiseScale), 3);
+    }
+
+    float gust = 0.0;
+    if (Get(windGustSpeed) > 0.0)
+    {
+        gust = texGust((pivotPosition - gustWorldOffset) * Get(windGustWorldScale), 3);
+        gust = pow(gust, 2) * Get(windGustScale);
+    }
+
+    float3 trunkNoise = (
+        (normalizedDir * Get(windWorldDirectionAndSpeed.w))
+        + (gust * normalizedDir * Get(windGustSpeed))
+        + (trunk * Get(windTurbulence))
+    ) * drag;
+
+    float3 dir = trunkNoise;
+    float flex = length(trunkNoise) + initialBend;
+
+    result.Direction = dir;
+    result.Strength = flex;
+    result.Gust = (gust * normalizedDir * Get(windGustSpeed)) + (trunk * Get(windTurbulence));
+
+    return result;
+}
+
+void ApplyWindDisplacement(inout float3 positionWS, inout WindData windData, float3 normalWS, float3 rootWP, float stifness, float drag, float initialBend, float time)
+{
+    WindData wind = GetAnalyticalWind(positionWS, rootWP, drag, initialBend, time);
+
+    if (wind.Strength > 0.0)
+    {
+        float att = AttenuateTrunk(distance(positionWS, rootWP), stifness);
+        float3 rotAxis = cross(float3(0, 1, 0), wind.Direction);
+
+        positionWS = Rotate(rootWP, positionWS, rotAxis, wind.Strength * 0.001 * att);
+    }
+
+    windData = wind;
+}
+
+#endif // _WIND_H

--- a/src/systems/patch_prop_system.zig
+++ b/src/systems/patch_prop_system.zig
@@ -37,7 +37,7 @@ pub const SystemState = struct {
     requester_id: world_patch_manager.RequesterId,
     comp_query_loader: ecsu.Query,
     medium_house_prefab: ecsu.Entity,
-    fir_tree_prefab: ecsu.Entity,
+    tree_prefab: ecsu.Entity,
     cube_prefab: ecsu.Entity,
 };
 
@@ -57,7 +57,7 @@ pub fn create(
     const flecs_sys = ecsu_world.newWrappedRunSystem(name.toCString(), ecs.OnUpdate, fd.NOCOMP, update, .{ .ctx = system });
 
     const medium_house_prefab = prefab_mgr.getPrefab(config.prefab.medium_house_id).?;
-    const fir_tree_prefab = prefab_mgr.getPrefab(config.prefab.fir_id).?;
+    const tree_prefab = prefab_mgr.getPrefab(config.prefab.beech_tree_04_id).?;
     const cube_prefab = prefab_mgr.getPrefab(config.prefab.cube_id).?;
 
     system.* = .{
@@ -70,7 +70,7 @@ pub fn create(
         .requester_id = world_patch_mgr.registerRequester(IdLocal.init("props")),
         .patches = std.ArrayList(Patch).initCapacity(allocator, 32 * 32) catch unreachable,
         .medium_house_prefab = medium_house_prefab,
-        .fir_tree_prefab = fir_tree_prefab,
+        .tree_prefab = tree_prefab,
         .cube_prefab = cube_prefab,
     };
 
@@ -256,7 +256,7 @@ fn updatePatches(system: *SystemState) void {
                     house_ent.set(fd.Scale.createScalar(prop_scale));
                     patch.entities.append(house_ent.id) catch unreachable;
                 } else if (prop.id.hash == tree_id.hash) {
-                    var fir_tree_ent = system.prefab_mgr.instantiatePrefab(system.ecsu_world, system.fir_tree_prefab);
+                    var fir_tree_ent = system.prefab_mgr.instantiatePrefab(system.ecsu_world, system.tree_prefab);
                     fir_tree_ent.set(prop_transform);
                     fir_tree_ent.set(prop_pos);
                     fir_tree_ent.set(prop_rot);

--- a/src/systems/renderer_system.zig
+++ b/src/systems/renderer_system.zig
@@ -188,7 +188,9 @@ fn preUpdate(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     defer ecs.iter_fini(iter.iter);
     const system: *SystemState = @ptrCast(@alignCast(iter.iter.ctx));
     var rctx = system.renderer;
-    rctx.time += iter.iter.delta_time;
+
+    const environment_info = system.ecsu_world.getSingleton(fd.EnvironmentInfo).?;
+    rctx.time = environment_info.world_time;
 
     if (rctx.window.frame_buffer_size[0] != rctx.window_width or rctx.window.frame_buffer_size[1] != rctx.window_height) {
         rctx.window_width = rctx.window.frame_buffer_size[0];

--- a/src/systems/renderer_system.zig
+++ b/src/systems/renderer_system.zig
@@ -187,6 +187,7 @@ fn preUpdate(iter: *ecsu.Iterator(fd.NOCOMP)) void {
     defer ecs.iter_fini(iter.iter);
     const system: *SystemState = @ptrCast(@alignCast(iter.iter.ctx));
     var rctx = system.renderer;
+    rctx.time += iter.iter.delta_time;
 
     if (rctx.window.frame_buffer_size[0] != rctx.window_width or rctx.window.frame_buffer_size[1] != rctx.window_height) {
         rctx.window_width = rctx.window.frame_buffer_size[0];

--- a/src/systems/renderer_system.zig
+++ b/src/systems/renderer_system.zig
@@ -6,6 +6,7 @@ const ecsu = @import("../flecs_util/flecs_util.zig");
 const fd = @import("../config/flecs_data.zig");
 const im3d = @import("im3d");
 const IdLocal = @import("../core/core.zig").IdLocal;
+const PrefabManager = @import("../prefab_manager.zig").PrefabManager;
 const renderer = @import("../renderer/renderer.zig");
 const zforge = @import("zforge");
 const util = @import("../util.zig");
@@ -51,6 +52,7 @@ pub const SystemCtx = struct {
     allocator: std.mem.Allocator,
     ecsu_world: ecsu.World,
     renderer: *renderer.Renderer,
+    prefab_mgr: *PrefabManager,
     world_patch_mgr: *world_patch_manager.WorldPatchManager,
 };
 
@@ -60,7 +62,7 @@ pub fn create(name: IdLocal, ctx: SystemCtx) !*SystemState {
     const pre_sys = ctx.ecsu_world.newWrappedRunSystem("Render System PreUpdate", ecs.PreUpdate, fd.NOCOMP, preUpdate, .{ .ctx = system });
     const post_sys = ctx.ecsu_world.newWrappedRunSystem("Render System PostUpdate", ecs.PostUpdate, fd.NOCOMP, postUpdate, .{ .ctx = system });
 
-    const geometry_pass = GeometryRenderPass.create(ctx.renderer, ctx.ecsu_world, ctx.allocator);
+    const geometry_pass = GeometryRenderPass.create(ctx.renderer, ctx.ecsu_world, ctx.prefab_mgr, ctx.allocator);
     ctx.renderer.render_gbuffer_pass_render_fn = geometry_render_pass.renderFn;
     ctx.renderer.render_gbuffer_pass_render_shadow_map_fn = geometry_render_pass.renderShadowMapFn;
     ctx.renderer.render_gbuffer_pass_create_descriptor_sets_fn = geometry_render_pass.createDescriptorSetsFn;

--- a/src/systems/renderer_system/geometry_render_pass.zig
+++ b/src/systems/renderer_system/geometry_render_pass.zig
@@ -304,6 +304,7 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
@@ -342,6 +343,7 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
@@ -431,6 +433,7 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
@@ -469,6 +472,7 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);

--- a/src/systems/renderer_system/geometry_render_pass.zig
+++ b/src/systems/renderer_system/geometry_render_pass.zig
@@ -25,6 +25,7 @@ pub const ShadowsUniformFrameData = struct {
 
 const InstanceData = struct {
     object_to_world: [16]f32,
+    materials_buffer_offset: u32,
 };
 
 const InstanceMaterial = struct {
@@ -632,6 +633,8 @@ fn cullStaticMeshes(self: *GeometryRenderPass) void {
             const material = comps.mesh.materials[sub_mesh_index];
             const entity_type_index = if (material.surface_type == .@"opaque") opaque_entities_index else masked_entities_index;
 
+            const material_buffer_offset = self.instance_materials[entity_type_index].items.len * @sizeOf(InstanceMaterial);
+
             self.instance_materials[entity_type_index].append(.{
                 .albedo_color = [4]f32{ material.base_color.r, material.base_color.g, material.base_color.b, 1.0 },
                 .roughness = material.roughness,
@@ -648,6 +651,7 @@ fn cullStaticMeshes(self: *GeometryRenderPass) void {
 
             var instance_data: InstanceData = undefined;
             zm.storeMat(&instance_data.object_to_world, z_world);
+            instance_data.materials_buffer_offset = @intCast(material_buffer_offset);
             self.instance_data[entity_type_index].append(instance_data) catch unreachable;
         }
     }

--- a/src/systems/renderer_system/geometry_render_pass.zig
+++ b/src/systems/renderer_system/geometry_render_pass.zig
@@ -18,14 +18,28 @@ pub const UniformFrameData = struct {
     projection_view: [16]f32,
     projection_view_inverted: [16]f32,
     camera_position: [4]f32,
+    time: f32,
 };
 
 pub const ShadowsUniformFrameData = struct {
     projection_view: [16]f32,
+    time: f32,
+};
+
+pub const WindFrameData = struct {
+    world_direction_and_speed: [4]f32,
+    flex_noise_scale: f32,
+    turbulence: f32,
+    gust_speed: f32,
+    gust_scale: f32,
+    gust_world_scale: f32,
+    noise_texture_index: u32,
+    gust_texture_index: u32,
 };
 
 const InstanceData = struct {
     object_to_world: [16]f32,
+    world_to_object: [16]f32,
     materials_buffer_offset: u32,
     _padding: [3]f32,
 };
@@ -40,14 +54,24 @@ const InstanceMaterial = struct {
     emissive_texture_index: u32,
     normal_texture_index: u32,
     arm_texture_index: u32,
+    wind_feature: u32,
+    wind_initial_bend: f32,
+    wind_stifness: f32,
+    wind_drag: f32,
+    wind_shiver_feature: u32,
+    wind_shiver_drag: f32,
+    wind_normal_influence: f32,
+    wind_shiver_directionality: f32,
 };
 
 const DrawCallInfo = struct {
+    pipeline_id: IdLocal,
     mesh_handle: renderer.MeshHandle,
     sub_mesh_index: u32,
 };
 
 const DrawCallInstanced = struct {
+    pipeline_id: IdLocal,
     mesh_handle: renderer.MeshHandle,
     sub_mesh_index: u32,
     start_instance_location: u32,
@@ -77,25 +101,63 @@ pub const GeometryRenderPass = struct {
     prefab_mgr: *PrefabManager,
     query_static_mesh: ecsu.Query,
 
-    shadows_uniform_frame_data: ShadowsUniformFrameData,
-    shadows_uniform_frame_buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle,
-    shadows_descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet,
-
     uniform_frame_data: UniformFrameData,
     uniform_frame_buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    // TODO(gmodarelli): Descriptor Set should be associated to materials
     descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet,
 
-    instance_data_buffers: [max_entity_types][renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    shadows_uniform_frame_data: ShadowsUniformFrameData,
+    shadows_uniform_frame_buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    // TODO(gmodarelli): Descriptor Set should be associated to materials
+    shadows_descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet,
+
+    wind_noise_texture: renderer.TextureHandle,
+    wind_gust_texture: renderer.TextureHandle,
+    wind_frame_data: WindFrameData,
+    wind_frame_buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    // TODO(gmodarelli): Descriptor Set should be associated to materials
+    tree_descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet,
+    shadows_tree_descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet,
+
     material_buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle,
     material_buffer_offset_hashmap: MaterialBufferOffsetHashmap,
 
-    instance_data: [max_entity_types]std.ArrayList(InstanceData),
+    gbuffer_instance_data_buffers: [max_entity_types][renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    shadow_caster_instance_data_buffers: [max_entity_types][renderer.Renderer.data_buffer_count]renderer.BufferHandle,
+    draw_calls_info: std.ArrayList(DrawCallInfo),
 
-    draw_calls_info: [max_entity_types]std.ArrayList(DrawCallInfo),
-    draw_calls: [max_entity_types]std.ArrayList(DrawCallInstanced),
-    draw_calls_push_constants: [max_entity_types]std.ArrayList(DrawCallPushConstants),
+    gbuffer_instance_data: [max_entity_types]std.ArrayList(InstanceData),
+    gbuffer_draw_calls: [max_entity_types]std.ArrayList(DrawCallInstanced),
+    gbuffer_draw_calls_push_constants: [max_entity_types]std.ArrayList(DrawCallPushConstants),
+
+    shadow_caster_instance_data: [max_entity_types]std.ArrayList(InstanceData),
+    shadow_caster_draw_calls: [max_entity_types]std.ArrayList(DrawCallInstanced),
+    shadow_caster_draw_calls_push_constants: [max_entity_types]std.ArrayList(DrawCallPushConstants),
 
     pub fn create(rctx: *renderer.Renderer, ecsu_world: ecsu.World, prefab_mgr: *PrefabManager, allocator: std.mem.Allocator) *GeometryRenderPass {
+        const wind_noise_texture = rctx.loadTexture("textures/noise/3d_noise.dds");
+        const wind_gust_texture = rctx.loadTexture("textures/noise/gust_noise.dds");
+
+        const wind_frame_data = WindFrameData{
+            .world_direction_and_speed = [4]f32{ 0, 0, 1, 20 },
+            .flex_noise_scale = 175,
+            .turbulence = 0.25,
+            .gust_speed = 20,
+            .gust_scale = 1.6,
+            .gust_world_scale = 600,
+            .noise_texture_index = rctx.getTextureBindlessIndex(wind_noise_texture),
+            .gust_texture_index = rctx.getTextureBindlessIndex(wind_gust_texture),
+        };
+
+        const wind_frame_buffers = blk: {
+            var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
+            for (buffers, 0..) |_, buffer_index| {
+                buffers[buffer_index] = rctx.createUniformBuffer(WindFrameData);
+            }
+
+            break :blk buffers;
+        };
+
         const shadows_uniform_frame_buffers = blk: {
             var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
             for (buffers, 0..) |_, buffer_index| {
@@ -114,27 +176,53 @@ pub const GeometryRenderPass = struct {
             break :blk buffers;
         };
 
-        const opaque_instance_data_buffers = blk: {
+        const gbuffer_opaque_instance_data_buffers = blk: {
             var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
             for (buffers, 0..) |_, buffer_index| {
                 const buffer_data = renderer.Slice{
                     .data = null,
                     .size = max_instances * @sizeOf(InstanceData),
                 };
-                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "Instance Transform Buffer: Opaque");
+                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "GBuffer Instances Opaque");
             }
 
             break :blk buffers;
         };
 
-        const masked_instance_data_buffers = blk: {
+        const gbuffer_masked_instance_data_buffers = blk: {
             var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
             for (buffers, 0..) |_, buffer_index| {
                 const buffer_data = renderer.Slice{
                     .data = null,
                     .size = max_instances * @sizeOf(InstanceData),
                 };
-                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "Instance Transform Buffer: Masked");
+                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "GBuffer Instances Masked");
+            }
+
+            break :blk buffers;
+        };
+
+        const shadow_caster_opaque_instance_data_buffers = blk: {
+            var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
+            for (buffers, 0..) |_, buffer_index| {
+                const buffer_data = renderer.Slice{
+                    .data = null,
+                    .size = max_instances * @sizeOf(InstanceData),
+                };
+                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "Shadow Caster Instances Opaque");
+            }
+
+            break :blk buffers;
+        };
+
+        const shadow_caster_masked_instance_data_buffers = blk: {
+            var buffers: [renderer.Renderer.data_buffer_count]renderer.BufferHandle = undefined;
+            for (buffers, 0..) |_, buffer_index| {
+                const buffer_data = renderer.Slice{
+                    .data = null,
+                    .size = max_instances * @sizeOf(InstanceData),
+                };
+                buffers[buffer_index] = rctx.createBindlessBuffer(buffer_data, "Shadow Caster Instances Masked");
             }
 
             break :blk buffers;
@@ -162,6 +250,14 @@ pub const GeometryRenderPass = struct {
                 .emissive_texture_index = rctx.getTextureBindlessIndex(material.emissive),
                 .normal_texture_index = rctx.getTextureBindlessIndex(material.normal),
                 .arm_texture_index = rctx.getTextureBindlessIndex(material.arm),
+                .wind_feature = if (material.wind_feature) 1 else 0,
+                .wind_initial_bend = material.wind_initial_bend,
+                .wind_stifness = material.wind_stifness,
+                .wind_drag = material.wind_drag,
+                .wind_shiver_feature = if (material.wind_shiver_feature) 1 else 0,
+                .wind_shiver_drag = material.wind_shiver_drag,
+                .wind_normal_influence = material.wind_normal_influence,
+                .wind_shiver_directionality = material.wind_shiver_directionality,
             }) catch unreachable;
         }
 
@@ -178,11 +274,15 @@ pub const GeometryRenderPass = struct {
             break :blk buffers;
         };
 
-        const draw_calls = [max_entity_types]std.ArrayList(DrawCallInstanced){ std.ArrayList(DrawCallInstanced).init(allocator), std.ArrayList(DrawCallInstanced).init(allocator) };
-        const draw_calls_push_constants = [max_entity_types]std.ArrayList(DrawCallPushConstants){ std.ArrayList(DrawCallPushConstants).init(allocator), std.ArrayList(DrawCallPushConstants).init(allocator) };
-        const draw_calls_info = [max_entity_types]std.ArrayList(DrawCallInfo){ std.ArrayList(DrawCallInfo).init(allocator), std.ArrayList(DrawCallInfo).init(allocator) };
+        const draw_calls_info = std.ArrayList(DrawCallInfo).init(allocator);
 
-        const instance_data = [max_entity_types]std.ArrayList(InstanceData){ std.ArrayList(InstanceData).init(allocator), std.ArrayList(InstanceData).init(allocator) };
+        const gbuffer_instance_data = [max_entity_types]std.ArrayList(InstanceData){ std.ArrayList(InstanceData).init(allocator), std.ArrayList(InstanceData).init(allocator) };
+        const gbuffer_draw_calls = [max_entity_types]std.ArrayList(DrawCallInstanced){ std.ArrayList(DrawCallInstanced).init(allocator), std.ArrayList(DrawCallInstanced).init(allocator) };
+        const gbuffer_draw_calls_push_constants = [max_entity_types]std.ArrayList(DrawCallPushConstants){ std.ArrayList(DrawCallPushConstants).init(allocator), std.ArrayList(DrawCallPushConstants).init(allocator) };
+
+        const shadow_caster_instance_data = [max_entity_types]std.ArrayList(InstanceData){ std.ArrayList(InstanceData).init(allocator), std.ArrayList(InstanceData).init(allocator) };
+        const shadow_caster_draw_calls = [max_entity_types]std.ArrayList(DrawCallInstanced){ std.ArrayList(DrawCallInstanced).init(allocator), std.ArrayList(DrawCallInstanced).init(allocator) };
+        const shadow_caster_draw_calls_push_constants = [max_entity_types]std.ArrayList(DrawCallPushConstants){ std.ArrayList(DrawCallPushConstants).init(allocator), std.ArrayList(DrawCallPushConstants).init(allocator) };
 
         // Queries
         var query_builder_mesh = ecsu.QueryBuilder.init(ecsu_world);
@@ -197,19 +297,29 @@ pub const GeometryRenderPass = struct {
             .ecsu_world = ecsu_world,
             .renderer = rctx,
             .prefab_mgr = prefab_mgr,
+            .wind_frame_data = wind_frame_data,
+            .wind_frame_buffers = wind_frame_buffers,
+            .wind_noise_texture = wind_noise_texture,
+            .wind_gust_texture = wind_gust_texture,
+            .tree_descriptor_sets = undefined,
+            .shadows_tree_descriptor_sets = undefined,
             .shadows_uniform_frame_data = std.mem.zeroes(ShadowsUniformFrameData),
             .shadows_uniform_frame_buffers = shadows_uniform_frame_buffers,
             .shadows_descriptor_sets = undefined,
             .uniform_frame_data = std.mem.zeroes(UniformFrameData),
             .uniform_frame_buffers = uniform_frame_buffers,
             .descriptor_sets = undefined,
-            .instance_data_buffers = .{ masked_instance_data_buffers, opaque_instance_data_buffers },
+            .gbuffer_instance_data_buffers = .{ gbuffer_masked_instance_data_buffers, gbuffer_opaque_instance_data_buffers },
+            .shadow_caster_instance_data_buffers = .{ shadow_caster_masked_instance_data_buffers, shadow_caster_opaque_instance_data_buffers },
             .material_buffers = material_buffers,
             .material_buffer_offset_hashmap = material_buffer_offset_hashmap,
-            .draw_calls = draw_calls,
-            .draw_calls_push_constants = draw_calls_push_constants,
             .draw_calls_info = draw_calls_info,
-            .instance_data = instance_data,
+            .gbuffer_instance_data = gbuffer_instance_data,
+            .gbuffer_draw_calls = gbuffer_draw_calls,
+            .gbuffer_draw_calls_push_constants = gbuffer_draw_calls_push_constants,
+            .shadow_caster_instance_data = shadow_caster_instance_data,
+            .shadow_caster_draw_calls = shadow_caster_draw_calls,
+            .shadow_caster_draw_calls_push_constants = shadow_caster_draw_calls_push_constants,
             .query_static_mesh = query_static_mesh,
         };
 
@@ -230,15 +340,23 @@ pub const GeometryRenderPass = struct {
             graphics.removeDescriptorSet(self.renderer.renderer, descriptor_set);
         }
 
-        self.instance_data[opaque_entities_index].deinit();
-        self.instance_data[masked_entities_index].deinit();
         self.material_buffer_offset_hashmap.deinit();
-        self.draw_calls[opaque_entities_index].deinit();
-        self.draw_calls[masked_entities_index].deinit();
-        self.draw_calls_push_constants[opaque_entities_index].deinit();
-        self.draw_calls_push_constants[masked_entities_index].deinit();
-        self.draw_calls_info[opaque_entities_index].deinit();
-        self.draw_calls_info[masked_entities_index].deinit();
+        self.draw_calls_info.deinit();
+
+        self.gbuffer_instance_data[opaque_entities_index].deinit();
+        self.gbuffer_instance_data[masked_entities_index].deinit();
+        self.gbuffer_draw_calls[opaque_entities_index].deinit();
+        self.gbuffer_draw_calls[masked_entities_index].deinit();
+        self.gbuffer_draw_calls_push_constants[opaque_entities_index].deinit();
+        self.gbuffer_draw_calls_push_constants[masked_entities_index].deinit();
+
+        self.shadow_caster_instance_data[opaque_entities_index].deinit();
+        self.shadow_caster_instance_data[masked_entities_index].deinit();
+        self.shadow_caster_draw_calls[opaque_entities_index].deinit();
+        self.shadow_caster_draw_calls[masked_entities_index].deinit();
+        self.shadow_caster_draw_calls_push_constants[opaque_entities_index].deinit();
+        self.shadow_caster_draw_calls_push_constants[masked_entities_index].deinit();
+
         self.allocator.destroy(self);
     }
 };
@@ -255,6 +373,20 @@ pub const renderShadowMapFn: renderer.renderPassRenderShadowMapFn = renderShadow
 pub const createDescriptorSetsFn: renderer.renderPassCreateDescriptorSetsFn = createDescriptorSets;
 pub const prepareDescriptorSetsFn: renderer.renderPassPrepareDescriptorSetsFn = prepareDescriptorSets;
 pub const unloadDescriptorSetsFn: renderer.renderPassUnloadDescriptorSetsFn = unloadDescriptorSets;
+
+fn bindMeshBuffers(self: *GeometryRenderPass, mesh: renderer.Mesh, cmd_list: [*c]graphics.Cmd) void {
+    const vertex_layout = self.renderer.getVertexLayout(mesh.vertex_layout_id).?;
+    const vertex_buffer_count_max = 12; // TODO(gmodarelli): Use MAX_SEMANTICS
+    var vertex_buffers: [vertex_buffer_count_max][*c]graphics.Buffer = undefined;
+
+    for (0..vertex_layout.mAttribCount) |attribute_index| {
+        const buffer = mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(vertex_layout.mAttribs[attribute_index].mSemantic)]].pBuffer;
+        vertex_buffers[attribute_index] = buffer;
+    }
+
+    graphics.cmdBindVertexBuffer(cmd_list, vertex_layout.mAttribCount, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
+    graphics.cmdBindIndexBuffer(cmd_list, mesh.buffer.*.mIndex.pBuffer, mesh.geometry.*.bitfield_1.mIndexType, 0);
+}
 
 fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
     const trazy_zone = ztracy.ZoneNC(@src(), "Geometry Render Pass", 0x00_ff_ff_00);
@@ -276,39 +408,88 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
     zm.storeMat(&self.uniform_frame_data.projection_view, z_proj_view);
     zm.storeMat(&self.uniform_frame_data.projection_view_inverted, zm.inverse(z_proj_view));
     self.uniform_frame_data.camera_position = [4]f32{ camera_position[0], camera_position[1], camera_position[2], 1.0 };
+    self.uniform_frame_data.time = self.renderer.time;
 
-    const data = renderer.Slice{
-        .data = @ptrCast(&self.uniform_frame_data),
-        .size = @sizeOf(UniformFrameData),
-    };
-    self.renderer.updateBuffer(data, UniformFrameData, self.uniform_frame_buffers[frame_index]);
-
-    // Render Lit Masked Objects
+    // Update Uniform Frame Buffer
     {
-        const pipeline_id = IdLocal.init("lit_masked");
-        const pipeline = self.renderer.getPSO(pipeline_id);
-        const root_signature = self.renderer.getRootSignature(pipeline_id);
-        graphics.cmdBindPipeline(cmd_list, pipeline);
-        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[masked_entities_index]);
+        const data = renderer.Slice{
+            .data = @ptrCast(&self.uniform_frame_data),
+            .size = @sizeOf(UniformFrameData),
+        };
+        self.renderer.updateBuffer(data, UniformFrameData, self.uniform_frame_buffers[frame_index]);
+    }
 
-        const root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
-        std.debug.assert(root_constant_index != std.math.maxInt(u32));
+    // Update Wind Frame Buffer
+    {
+        const data = renderer.Slice{
+            .data = @ptrCast(&self.wind_frame_data),
+            .size = @sizeOf(WindFrameData),
+        };
+        self.renderer.updateBuffer(data, WindFrameData, self.wind_frame_buffers[frame_index]);
+    }
 
-        for (self.draw_calls[masked_entities_index].items, 0..) |draw_call, i| {
-            const push_constants = &self.draw_calls_push_constants[masked_entities_index].items[i];
+    // Render GBuffer Masked Objects
+    {
+        cullAndBatchDrawCalls(
+            self,
+            camera_entity,
+            &self.gbuffer_instance_data[masked_entities_index],
+            &self.gbuffer_draw_calls[masked_entities_index],
+            &self.gbuffer_draw_calls_push_constants[masked_entities_index],
+            self.gbuffer_instance_data_buffers[masked_entities_index][frame_index],
+            self.material_buffers[frame_index],
+            .masked,
+            .gbuffer,
+        );
+
+        const instance_data_slice = renderer.Slice{
+            .data = @ptrCast(self.gbuffer_instance_data[masked_entities_index].items),
+            .size = self.gbuffer_instance_data[masked_entities_index].items.len * @sizeOf(InstanceData),
+        };
+        self.renderer.updateBuffer(instance_data_slice, InstanceData, self.gbuffer_instance_data_buffers[masked_entities_index][frame_index]);
+
+        var pipeline_id: IdLocal = undefined;
+        var pipeline: [*c]graphics.Pipeline = undefined;
+        var root_signature: [*c]graphics.RootSignature = undefined;
+        var root_constant_index: u32 = 0;
+
+        for (self.gbuffer_draw_calls[masked_entities_index].items, 0..) |draw_call, i| {
+            if (i == 0) {
+                pipeline_id = draw_call.pipeline_id;
+                pipeline = self.renderer.getPSO(pipeline_id);
+                root_signature = self.renderer.getRootSignature(pipeline_id);
+                graphics.cmdBindPipeline(cmd_list, pipeline);
+                if (pipeline_id.hash == renderer.masked_pipelines[2].hash) {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.tree_descriptor_sets[masked_entities_index]);
+                } else {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[masked_entities_index]);
+                }
+
+                root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                std.debug.assert(root_constant_index != std.math.maxInt(u32));
+            } else {
+                if (pipeline_id.hash != draw_call.pipeline_id.hash) {
+                    pipeline_id = draw_call.pipeline_id;
+                    pipeline = self.renderer.getPSO(pipeline_id);
+                    root_signature = self.renderer.getRootSignature(pipeline_id);
+                    graphics.cmdBindPipeline(cmd_list, pipeline);
+                    if (pipeline_id.hash == renderer.masked_pipelines[2].hash) {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.tree_descriptor_sets[masked_entities_index]);
+                    } else {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[masked_entities_index]);
+                    }
+
+                    root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                    std.debug.assert(root_constant_index != std.math.maxInt(u32));
+                }
+            }
+
+            const push_constants = &self.gbuffer_draw_calls_push_constants[masked_entities_index].items[i];
             const mesh = self.renderer.getMesh(draw_call.mesh_handle);
 
             if (mesh.loaded) {
-                const vertex_buffers = [_][*c]graphics.Buffer{
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
-                };
+                bindMeshBuffers(self, mesh, cmd_list);
 
-                graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
-                graphics.cmdBindIndexBuffer(cmd_list, mesh.buffer.*.mIndex.pBuffer, mesh.geometry.*.bitfield_1.mIndexType, 0);
                 graphics.cmdBindPushConstants(cmd_list, root_signature, root_constant_index, @constCast(push_constants));
                 graphics.cmdDrawIndexedInstanced(
                     cmd_list,
@@ -322,32 +503,68 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
         }
     }
 
-    // Render Lit Objects
+    // Render GBuffer Opauqe Objects
     {
-        const pipeline_id = IdLocal.init("lit");
-        const pipeline = self.renderer.getPSO(pipeline_id);
-        const root_signature = self.renderer.getRootSignature(pipeline_id);
-        graphics.cmdBindPipeline(cmd_list, pipeline);
-        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[opaque_entities_index]);
+        cullAndBatchDrawCalls(
+            self,
+            camera_entity,
+            &self.gbuffer_instance_data[opaque_entities_index],
+            &self.gbuffer_draw_calls[opaque_entities_index],
+            &self.gbuffer_draw_calls_push_constants[opaque_entities_index],
+            self.gbuffer_instance_data_buffers[opaque_entities_index][frame_index],
+            self.material_buffers[frame_index],
+            .@"opaque",
+            .gbuffer,
+        );
 
-        const root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
-        std.debug.assert(root_constant_index != std.math.maxInt(u32));
+        const instance_data_slice = renderer.Slice{
+            .data = @ptrCast(self.gbuffer_instance_data[opaque_entities_index].items),
+            .size = self.gbuffer_instance_data[opaque_entities_index].items.len * @sizeOf(InstanceData),
+        };
+        self.renderer.updateBuffer(instance_data_slice, InstanceData, self.gbuffer_instance_data_buffers[opaque_entities_index][frame_index]);
 
-        for (self.draw_calls[opaque_entities_index].items, 0..) |draw_call, i| {
-            const push_constants = &self.draw_calls_push_constants[opaque_entities_index].items[i];
+        var pipeline_id: IdLocal = undefined;
+        var pipeline: [*c]graphics.Pipeline = undefined;
+        var root_signature: [*c]graphics.RootSignature = undefined;
+        var root_constant_index: u32 = 0;
+
+        for (self.gbuffer_draw_calls[opaque_entities_index].items, 0..) |draw_call, i| {
+            if (i == 0) {
+                pipeline_id = draw_call.pipeline_id;
+                pipeline = self.renderer.getPSO(pipeline_id);
+                root_signature = self.renderer.getRootSignature(pipeline_id);
+                graphics.cmdBindPipeline(cmd_list, pipeline);
+                if (pipeline_id.hash == renderer.opaque_pipelines[2].hash) {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.tree_descriptor_sets[opaque_entities_index]);
+                } else {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[opaque_entities_index]);
+                }
+
+                root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                std.debug.assert(root_constant_index != std.math.maxInt(u32));
+            } else {
+                if (pipeline_id.hash != draw_call.pipeline_id.hash) {
+                    pipeline_id = draw_call.pipeline_id;
+                    pipeline = self.renderer.getPSO(pipeline_id);
+                    root_signature = self.renderer.getRootSignature(pipeline_id);
+                    graphics.cmdBindPipeline(cmd_list, pipeline);
+                    if (pipeline_id.hash == renderer.opaque_pipelines[2].hash) {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.tree_descriptor_sets[opaque_entities_index]);
+                    } else {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.descriptor_sets[opaque_entities_index]);
+                    }
+
+                    root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                    std.debug.assert(root_constant_index != std.math.maxInt(u32));
+                }
+            }
+
+            const push_constants = &self.gbuffer_draw_calls_push_constants[opaque_entities_index].items[i];
             const mesh = self.renderer.getMesh(draw_call.mesh_handle);
 
             if (mesh.loaded) {
-                const vertex_buffers = [_][*c]graphics.Buffer{
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
-                };
+                bindMeshBuffers(self, mesh, cmd_list);
 
-                graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
-                graphics.cmdBindIndexBuffer(cmd_list, mesh.buffer.*.mIndex.pBuffer, mesh.geometry.*.bitfield_1.mIndexType, 0);
                 graphics.cmdBindPushConstants(cmd_list, root_signature, root_constant_index, @constCast(push_constants));
                 graphics.cmdDrawIndexedInstanced(
                     cmd_list,
@@ -367,10 +584,6 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
     defer trazy_zone.End();
 
     const self: *GeometryRenderPass = @ptrCast(@alignCast(user_data));
-    // HACK(gmodarelli): We're not really culling here but only batching. We need to pass
-    // a view so we can cull and batch from different views (light or camera)
-    cullStaticMeshes(self);
-
     const frame_index = self.renderer.frame_index;
 
     var camera_entity = util.getActiveCameraEnt(self.ecsu_world);
@@ -397,6 +610,7 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
     const z_proj = zm.orthographicLh(shadow_range, shadow_range, -500.0, 500.0);
     const z_proj_view = zm.mul(z_view, z_proj);
     zm.storeMat(&self.shadows_uniform_frame_data.projection_view, z_proj_view);
+    self.shadows_uniform_frame_data.time = self.renderer.time;
 
     const data = renderer.Slice{
         .data = @ptrCast(&self.shadows_uniform_frame_data),
@@ -404,40 +618,68 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
     };
     self.renderer.updateBuffer(data, ShadowsUniformFrameData, self.shadows_uniform_frame_buffers[frame_index]);
 
-    for (0..max_entity_types) |entity_type_index| {
-        const instance_data_slice = renderer.Slice{
-            .data = @ptrCast(self.instance_data[entity_type_index].items),
-            .size = self.instance_data[entity_type_index].items.len * @sizeOf(InstanceData),
-        };
-        self.renderer.updateBuffer(instance_data_slice, InstanceData, self.instance_data_buffers[entity_type_index][frame_index]);
-    }
-
-    // Render Shadows Lit Masked Objects
+    // Render Shadows Masked Objects
     {
-        const pipeline_id = IdLocal.init("shadows_lit_masked");
-        const pipeline = self.renderer.getPSO(pipeline_id);
-        const root_signature = self.renderer.getRootSignature(pipeline_id);
-        graphics.cmdBindPipeline(cmd_list, pipeline);
-        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[masked_entities_index]);
+        cullAndBatchDrawCalls(
+            self,
+            camera_entity,
+            &self.shadow_caster_instance_data[masked_entities_index],
+            &self.shadow_caster_draw_calls[masked_entities_index],
+            &self.shadow_caster_draw_calls_push_constants[masked_entities_index],
+            self.shadow_caster_instance_data_buffers[masked_entities_index][frame_index],
+            self.material_buffers[frame_index],
+            .masked,
+            .shadow_caster,
+        );
 
-        const root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
-        std.debug.assert(root_constant_index != std.math.maxInt(u32));
+        const instance_data_slice = renderer.Slice{
+            .data = @ptrCast(self.shadow_caster_instance_data[masked_entities_index].items),
+            .size = self.shadow_caster_instance_data[masked_entities_index].items.len * @sizeOf(InstanceData),
+        };
+        self.renderer.updateBuffer(instance_data_slice, InstanceData, self.shadow_caster_instance_data_buffers[masked_entities_index][frame_index]);
 
-        for (self.draw_calls[masked_entities_index].items, 0..) |draw_call, i| {
-            const push_constants = &self.draw_calls_push_constants[masked_entities_index].items[i];
+        var pipeline_id: IdLocal = undefined;
+        var pipeline: [*c]graphics.Pipeline = undefined;
+        var root_signature: [*c]graphics.RootSignature = undefined;
+        var root_constant_index: u32 = 0;
+
+        for (self.shadow_caster_draw_calls[masked_entities_index].items, 0..) |draw_call, i| {
+            if (i == 0) {
+                pipeline_id = draw_call.pipeline_id;
+                pipeline = self.renderer.getPSO(pipeline_id);
+                root_signature = self.renderer.getRootSignature(pipeline_id);
+                graphics.cmdBindPipeline(cmd_list, pipeline);
+                if (pipeline_id.hash == renderer.masked_pipelines[3].hash) {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_tree_descriptor_sets[masked_entities_index]);
+                } else {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[masked_entities_index]);
+                }
+
+                root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                std.debug.assert(root_constant_index != std.math.maxInt(u32));
+            } else {
+                if (pipeline_id.hash != draw_call.pipeline_id.hash) {
+                    pipeline_id = draw_call.pipeline_id;
+                    pipeline = self.renderer.getPSO(pipeline_id);
+                    root_signature = self.renderer.getRootSignature(pipeline_id);
+                    graphics.cmdBindPipeline(cmd_list, pipeline);
+                    if (pipeline_id.hash == renderer.masked_pipelines[3].hash) {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_tree_descriptor_sets[masked_entities_index]);
+                    } else {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[masked_entities_index]);
+                    }
+
+                    root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                    std.debug.assert(root_constant_index != std.math.maxInt(u32));
+                }
+            }
+
+            const push_constants = &self.shadow_caster_draw_calls_push_constants[masked_entities_index].items[i];
             const mesh = self.renderer.getMesh(draw_call.mesh_handle);
 
             if (mesh.loaded) {
-                const vertex_buffers = [_][*c]graphics.Buffer{
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
-                };
+                bindMeshBuffers(self, mesh, cmd_list);
 
-                graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
-                graphics.cmdBindIndexBuffer(cmd_list, mesh.buffer.*.mIndex.pBuffer, mesh.geometry.*.bitfield_1.mIndexType, 0);
                 graphics.cmdBindPushConstants(cmd_list, root_signature, root_constant_index, @constCast(push_constants));
                 graphics.cmdDrawIndexedInstanced(
                     cmd_list,
@@ -451,32 +693,68 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
         }
     }
 
-    // Render Lit Objects
+    // Render Shadows Opauqe Objects
     {
-        const pipeline_id = IdLocal.init("shadows_lit");
-        const pipeline = self.renderer.getPSO(pipeline_id);
-        const root_signature = self.renderer.getRootSignature(pipeline_id);
-        graphics.cmdBindPipeline(cmd_list, pipeline);
-        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[opaque_entities_index]);
+        cullAndBatchDrawCalls(
+            self,
+            camera_entity,
+            &self.shadow_caster_instance_data[opaque_entities_index],
+            &self.shadow_caster_draw_calls[opaque_entities_index],
+            &self.shadow_caster_draw_calls_push_constants[opaque_entities_index],
+            self.shadow_caster_instance_data_buffers[opaque_entities_index][frame_index],
+            self.material_buffers[frame_index],
+            .@"opaque",
+            .shadow_caster,
+        );
 
-        const root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
-        std.debug.assert(root_constant_index != std.math.maxInt(u32));
+        const instance_data_slice = renderer.Slice{
+            .data = @ptrCast(self.shadow_caster_instance_data[opaque_entities_index].items),
+            .size = self.shadow_caster_instance_data[opaque_entities_index].items.len * @sizeOf(InstanceData),
+        };
+        self.renderer.updateBuffer(instance_data_slice, InstanceData, self.shadow_caster_instance_data_buffers[opaque_entities_index][frame_index]);
 
-        for (self.draw_calls[opaque_entities_index].items, 0..) |draw_call, i| {
-            const push_constants = &self.draw_calls_push_constants[opaque_entities_index].items[i];
+        var pipeline_id: IdLocal = undefined;
+        var pipeline: [*c]graphics.Pipeline = undefined;
+        var root_signature: [*c]graphics.RootSignature = undefined;
+        var root_constant_index: u32 = 0;
+
+        for (self.shadow_caster_draw_calls[opaque_entities_index].items, 0..) |draw_call, i| {
+            if (i == 0) {
+                pipeline_id = draw_call.pipeline_id;
+                pipeline = self.renderer.getPSO(pipeline_id);
+                root_signature = self.renderer.getRootSignature(pipeline_id);
+                graphics.cmdBindPipeline(cmd_list, pipeline);
+                if (pipeline_id.hash == renderer.opaque_pipelines[3].hash) {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_tree_descriptor_sets[opaque_entities_index]);
+                } else {
+                    graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[opaque_entities_index]);
+                }
+
+                root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                std.debug.assert(root_constant_index != std.math.maxInt(u32));
+            } else {
+                if (pipeline_id.hash != draw_call.pipeline_id.hash) {
+                    pipeline_id = draw_call.pipeline_id;
+                    pipeline = self.renderer.getPSO(pipeline_id);
+                    root_signature = self.renderer.getRootSignature(pipeline_id);
+                    graphics.cmdBindPipeline(cmd_list, pipeline);
+                    if (pipeline_id.hash == renderer.opaque_pipelines[3].hash) {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_tree_descriptor_sets[opaque_entities_index]);
+                    } else {
+                        graphics.cmdBindDescriptorSet(cmd_list, frame_index, self.shadows_descriptor_sets[opaque_entities_index]);
+                    }
+
+                    root_constant_index = graphics.getDescriptorIndexFromName(root_signature, "RootConstant");
+                    std.debug.assert(root_constant_index != std.math.maxInt(u32));
+                }
+            }
+
+            const push_constants = &self.shadow_caster_draw_calls_push_constants[opaque_entities_index].items[i];
             const mesh = self.renderer.getMesh(draw_call.mesh_handle);
 
             if (mesh.loaded) {
-                const vertex_buffers = [_][*c]graphics.Buffer{
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
-                };
+                bindMeshBuffers(self, mesh, cmd_list);
 
-                graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
-                graphics.cmdBindIndexBuffer(cmd_list, mesh.buffer.*.mIndex.pBuffer, mesh.geometry.*.bitfield_1.mIndexType, 0);
                 graphics.cmdBindPushConstants(cmd_list, root_signature, root_constant_index, @constCast(push_constants));
                 graphics.cmdDrawIndexedInstanced(
                     cmd_list,
@@ -515,6 +793,48 @@ fn createDescriptorSets(user_data: *anyopaque) void {
     };
     self.shadows_descriptor_sets = shadows_descriptor_sets;
 
+    const shadows_tree_descriptor_sets = blk: {
+        const root_signature_lit = self.renderer.getRootSignature(IdLocal.init("shadows_tree"));
+        const root_signature_lit_masked = self.renderer.getRootSignature(IdLocal.init("shadows_tree_masked"));
+
+        var descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet = undefined;
+        for (descriptor_sets, 0..) |_, index| {
+            var desc = std.mem.zeroes(graphics.DescriptorSetDesc);
+            desc.mUpdateFrequency = graphics.DescriptorUpdateFrequency.DESCRIPTOR_UPDATE_FREQ_PER_FRAME;
+            desc.mMaxSets = renderer.Renderer.data_buffer_count;
+            if (index == opaque_entities_index) {
+                desc.pRootSignature = root_signature_lit;
+            } else {
+                desc.pRootSignature = root_signature_lit_masked;
+            }
+            graphics.addDescriptorSet(self.renderer.renderer, &desc, @ptrCast(&descriptor_sets[index]));
+        }
+
+        break :blk descriptor_sets;
+    };
+    self.shadows_tree_descriptor_sets = shadows_tree_descriptor_sets;
+
+    const tree_descriptor_sets = blk: {
+        const root_signature_lit = self.renderer.getRootSignature(IdLocal.init("tree"));
+        const root_signature_lit_masked = self.renderer.getRootSignature(IdLocal.init("tree_masked"));
+
+        var descriptor_sets: [max_entity_types][*c]graphics.DescriptorSet = undefined;
+        for (descriptor_sets, 0..) |_, index| {
+            var desc = std.mem.zeroes(graphics.DescriptorSetDesc);
+            desc.mUpdateFrequency = graphics.DescriptorUpdateFrequency.DESCRIPTOR_UPDATE_FREQ_PER_FRAME;
+            desc.mMaxSets = renderer.Renderer.data_buffer_count;
+            if (index == opaque_entities_index) {
+                desc.pRootSignature = root_signature_lit;
+            } else {
+                desc.pRootSignature = root_signature_lit_masked;
+            }
+            graphics.addDescriptorSet(self.renderer.renderer, &desc, @ptrCast(&descriptor_sets[index]));
+        }
+
+        break :blk descriptor_sets;
+    };
+    self.tree_descriptor_sets = tree_descriptor_sets;
+
     const descriptor_sets = blk: {
         const root_signature_lit = self.renderer.getRootSignature(IdLocal.init("lit"));
         const root_signature_lit_masked = self.renderer.getRootSignature(IdLocal.init("lit_masked"));
@@ -540,7 +860,7 @@ fn createDescriptorSets(user_data: *anyopaque) void {
 fn prepareDescriptorSets(user_data: *anyopaque) void {
     const self: *GeometryRenderPass = @ptrCast(@alignCast(user_data));
 
-    var params: [1]graphics.DescriptorData = undefined;
+    var params: [2]graphics.DescriptorData = undefined;
 
     for (0..renderer.Renderer.data_buffer_count) |i| {
         var uniform_buffer = self.renderer.getBuffer(self.uniform_frame_buffers[i]);
@@ -561,6 +881,34 @@ fn prepareDescriptorSets(user_data: *anyopaque) void {
         graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.shadows_descriptor_sets[opaque_entities_index], 1, @ptrCast(&params));
         graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.shadows_descriptor_sets[masked_entities_index], 1, @ptrCast(&params));
     }
+
+    for (0..renderer.Renderer.data_buffer_count) |i| {
+        var uniform_buffer = self.renderer.getBuffer(self.uniform_frame_buffers[i]);
+        var wind_buffer = self.renderer.getBuffer(self.wind_frame_buffers[i]);
+        params[0] = std.mem.zeroes(graphics.DescriptorData);
+        params[0].pName = "cbFrame";
+        params[0].__union_field3.ppBuffers = @ptrCast(&uniform_buffer);
+        params[1] = std.mem.zeroes(graphics.DescriptorData);
+        params[1].pName = "cbWind";
+        params[1].__union_field3.ppBuffers = @ptrCast(&wind_buffer);
+
+        graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.tree_descriptor_sets[opaque_entities_index], 2, @ptrCast(&params));
+        graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.tree_descriptor_sets[masked_entities_index], 2, @ptrCast(&params));
+    }
+
+    for (0..renderer.Renderer.data_buffer_count) |i| {
+        var uniform_buffer = self.renderer.getBuffer(self.shadows_uniform_frame_buffers[i]);
+        var wind_buffer = self.renderer.getBuffer(self.wind_frame_buffers[i]);
+        params[0] = std.mem.zeroes(graphics.DescriptorData);
+        params[0].pName = "cbFrame";
+        params[0].__union_field3.ppBuffers = @ptrCast(&uniform_buffer);
+        params[1] = std.mem.zeroes(graphics.DescriptorData);
+        params[1].pName = "cbWind";
+        params[1].__union_field3.ppBuffers = @ptrCast(&wind_buffer);
+
+        graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.shadows_tree_descriptor_sets[opaque_entities_index], 2, @ptrCast(&params));
+        graphics.updateDescriptorSet(self.renderer.renderer, @intCast(i), self.shadows_tree_descriptor_sets[masked_entities_index], 2, @ptrCast(&params));
+    }
 }
 
 fn unloadDescriptorSets(user_data: *anyopaque) void {
@@ -570,12 +918,24 @@ fn unloadDescriptorSets(user_data: *anyopaque) void {
     graphics.removeDescriptorSet(self.renderer.renderer, self.descriptor_sets[masked_entities_index]);
     graphics.removeDescriptorSet(self.renderer.renderer, self.shadows_descriptor_sets[opaque_entities_index]);
     graphics.removeDescriptorSet(self.renderer.renderer, self.shadows_descriptor_sets[masked_entities_index]);
+
+    graphics.removeDescriptorSet(self.renderer.renderer, self.tree_descriptor_sets[opaque_entities_index]);
+    graphics.removeDescriptorSet(self.renderer.renderer, self.tree_descriptor_sets[masked_entities_index]);
+    graphics.removeDescriptorSet(self.renderer.renderer, self.shadows_tree_descriptor_sets[opaque_entities_index]);
+    graphics.removeDescriptorSet(self.renderer.renderer, self.shadows_tree_descriptor_sets[masked_entities_index]);
 }
 
-fn cullStaticMeshes(self: *GeometryRenderPass) void {
-    const frame_index = self.renderer.frame_index;
-
-    var camera_entity = util.getActiveCameraEnt(self.ecsu_world);
+fn cullAndBatchDrawCalls(
+    self: *GeometryRenderPass,
+    camera_entity: ecsu.Entity,
+    instances: *std.ArrayList(InstanceData),
+    draw_calls: *std.ArrayList(DrawCallInstanced),
+    draw_calls_push_constants: *std.ArrayList(DrawCallPushConstants),
+    instances_buffer: renderer.BufferHandle,
+    materials_buffer: renderer.BufferHandle,
+    surface_type: fd.SurfaceType,
+    technique: fd.ShadingTechnique,
+) void {
     const camera_comps = camera_entity.getComps(struct {
         camera: *const fd.Camera,
         transform: *const fd.Transform,
@@ -587,16 +947,13 @@ fn cullStaticMeshes(self: *GeometryRenderPass) void {
         mesh: *const fd.StaticMesh,
     });
 
-    // Reset transforms, materials and draw calls array list
-    for (0..max_entity_types) |entity_type_index| {
-        self.instance_data[entity_type_index].clearRetainingCapacity();
-        self.draw_calls[entity_type_index].clearRetainingCapacity();
-        self.draw_calls_push_constants[entity_type_index].clearRetainingCapacity();
-        self.draw_calls_info[entity_type_index].clearRetainingCapacity();
-    }
+    instances.clearRetainingCapacity();
+    draw_calls.clearRetainingCapacity();
+    draw_calls_push_constants.clearRetainingCapacity();
+
+    self.draw_calls_info.clearRetainingCapacity();
 
     // Iterate over all renderable meshes, perform frustum culling and generate instance transforms and materials
-    const loop1 = ztracy.ZoneNC(@src(), "Geometry Render Pass: Culling and Batching", 0x00_ff_ff_00);
     while (entity_iterator.next()) |comps| {
         const sub_mesh_count = self.renderer.getSubMeshCount(comps.mesh.mesh_handle);
         if (sub_mesh_count == 0) continue;
@@ -614,6 +971,7 @@ fn cullStaticMeshes(self: *GeometryRenderPass) void {
         // }
 
         var draw_call_info = DrawCallInfo{
+            .pipeline_id = undefined,
             .mesh_handle = comps.mesh.mesh_handle,
             .sub_mesh_index = undefined,
         };
@@ -621,98 +979,135 @@ fn cullStaticMeshes(self: *GeometryRenderPass) void {
         for (0..sub_mesh_count) |sub_mesh_index| {
             draw_call_info.sub_mesh_index = @intCast(sub_mesh_index);
 
-            var material_id = comps.mesh.materials[sub_mesh_index];
-            var material = self.prefab_mgr.getMaterial(IdLocal.init("M_default")).?;
+            const material_id = comps.mesh.materials[sub_mesh_index];
+            var material: fd.UberShader = undefined;
             if (self.prefab_mgr.getMaterial(material_id)) |m| {
                 material = m;
             } else {
-                material_id = IdLocal.init("M_default");
-            }
-            const material_buffer_offset = self.material_buffer_offset_hashmap.get(material_id).?;
-
-            const entity_type_index = if (material.surface_type == .@"opaque") opaque_entities_index else masked_entities_index;
-            self.draw_calls_info[entity_type_index].append(draw_call_info) catch unreachable;
-
-            var instance_data: InstanceData = undefined;
-            zm.storeMat(&instance_data.object_to_world, z_world);
-            instance_data.materials_buffer_offset = material_buffer_offset;
-            instance_data._padding = [3]f32{ 42.0, 42.0, 42.0 };
-            self.instance_data[entity_type_index].append(instance_data) catch unreachable;
-        }
-    }
-    loop1.End();
-
-    const loop2 = ztracy.ZoneNC(@src(), "Geometry Render Pass: Rendering", 0x00_ff_ff_00);
-    for (0..max_entity_types) |entity_type_index| {
-        var start_instance_location: u32 = 0;
-        var current_draw_call: DrawCallInstanced = undefined;
-
-        const instance_data_buffer_index = self.renderer.getBufferBindlessIndex(self.instance_data_buffers[entity_type_index][frame_index]);
-        const material_buffer_index = self.renderer.getBufferBindlessIndex(self.material_buffers[frame_index]);
-
-        if (self.draw_calls_info[entity_type_index].items.len == 0) continue;
-
-        for (self.draw_calls_info[entity_type_index].items, 0..) |draw_call_info, i| {
-            if (i == 0) {
-                current_draw_call = .{
-                    .mesh_handle = draw_call_info.mesh_handle,
-                    .sub_mesh_index = draw_call_info.sub_mesh_index,
-                    .instance_count = 1,
-                    .start_instance_location = start_instance_location,
-                };
-
-                start_instance_location += 1;
-
-                if (i == self.draw_calls_info[entity_type_index].items.len - 1) {
-                    self.draw_calls[entity_type_index].append(current_draw_call) catch unreachable;
-                    self.draw_calls_push_constants[entity_type_index].append(.{
-                        .start_instance_location = current_draw_call.start_instance_location,
-                        .instance_material_buffer_index = material_buffer_index,
-                        .instance_data_buffer_index = instance_data_buffer_index,
-                    }) catch unreachable;
-                }
                 continue;
             }
 
-            if (current_draw_call.mesh_handle.id == draw_call_info.mesh_handle.id and current_draw_call.sub_mesh_index == draw_call_info.sub_mesh_index) {
-                current_draw_call.instance_count += 1;
-                start_instance_location += 1;
+            const material_buffer_offset = self.material_buffer_offset_hashmap.get(material_id).?;
+            var pipeline_id: IdLocal = undefined;
 
-                if (i == self.draw_calls_info[entity_type_index].items.len - 1) {
-                    self.draw_calls[entity_type_index].append(current_draw_call) catch unreachable;
-                    self.draw_calls_push_constants[entity_type_index].append(.{
-                        .start_instance_location = current_draw_call.start_instance_location,
-                        .instance_material_buffer_index = material_buffer_index,
-                        .instance_data_buffer_index = instance_data_buffer_index,
-                    }) catch unreachable;
+            if (technique == .gbuffer) {
+                if (material.gbuffer_pipeline_id) |p_id| {
+                    pipeline_id = p_id;
+                } else {
+                    continue;
+                }
+            } else if (technique == .shadow_caster) {
+                if (material.shadow_caster_pipeline_id) |p_id| {
+                    pipeline_id = p_id;
+                } else {
+                    continue;
+                }
+            }
+
+            draw_call_info.pipeline_id = pipeline_id;
+
+            var should_parse_submesh = false;
+
+            if (surface_type == .@"opaque") {
+                for (renderer.opaque_pipelines) |pipeline| {
+                    if (pipeline_id.hash == pipeline.hash) {
+                        should_parse_submesh = true;
+                        break;
+                    }
                 }
             } else {
-                self.draw_calls[entity_type_index].append(current_draw_call) catch unreachable;
-                self.draw_calls_push_constants[entity_type_index].append(.{
+                for (renderer.masked_pipelines) |pipeline| {
+                    if (pipeline_id.hash == pipeline.hash) {
+                        should_parse_submesh = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!should_parse_submesh) {
+                continue;
+            }
+
+            self.draw_calls_info.append(draw_call_info) catch unreachable;
+
+            var instance_data: InstanceData = undefined;
+            zm.storeMat(&instance_data.object_to_world, z_world);
+            zm.storeMat(&instance_data.world_to_object, zm.inverse(z_world));
+            instance_data.materials_buffer_offset = material_buffer_offset;
+            instance_data._padding = [3]f32{ 42.0, 42.0, 42.0 };
+            instances.append(instance_data) catch unreachable;
+        }
+    }
+
+    if (self.draw_calls_info.items.len == 0) return;
+
+    var start_instance_location: u32 = 0;
+    var current_draw_call: DrawCallInstanced = undefined;
+
+    const instance_data_buffer_index = self.renderer.getBufferBindlessIndex(instances_buffer);
+    const material_buffer_index = self.renderer.getBufferBindlessIndex(materials_buffer);
+
+    for (self.draw_calls_info.items, 0..) |draw_call_info, i| {
+        if (i == 0) {
+            current_draw_call = .{
+                .pipeline_id = draw_call_info.pipeline_id,
+                .mesh_handle = draw_call_info.mesh_handle,
+                .sub_mesh_index = draw_call_info.sub_mesh_index,
+                .instance_count = 1,
+                .start_instance_location = start_instance_location,
+            };
+
+            start_instance_location += 1;
+
+            if (i == self.draw_calls_info.items.len - 1) {
+                draw_calls.append(current_draw_call) catch unreachable;
+                draw_calls_push_constants.append(.{
                     .start_instance_location = current_draw_call.start_instance_location,
                     .instance_material_buffer_index = material_buffer_index,
                     .instance_data_buffer_index = instance_data_buffer_index,
                 }) catch unreachable;
+            }
+            continue;
+        }
 
-                current_draw_call = .{
-                    .mesh_handle = draw_call_info.mesh_handle,
-                    .sub_mesh_index = draw_call_info.sub_mesh_index,
-                    .instance_count = 1,
-                    .start_instance_location = start_instance_location,
-                };
+        if (current_draw_call.mesh_handle.id == draw_call_info.mesh_handle.id and current_draw_call.sub_mesh_index == draw_call_info.sub_mesh_index and current_draw_call.pipeline_id.hash == draw_call_info.pipeline_id.hash) {
+            current_draw_call.instance_count += 1;
+            start_instance_location += 1;
 
-                start_instance_location += 1;
+            if (i == self.draw_calls_info.items.len - 1) {
+                draw_calls.append(current_draw_call) catch unreachable;
+                draw_calls_push_constants.append(.{
+                    .start_instance_location = current_draw_call.start_instance_location,
+                    .instance_material_buffer_index = material_buffer_index,
+                    .instance_data_buffer_index = instance_data_buffer_index,
+                }) catch unreachable;
+            }
+        } else {
+            draw_calls.append(current_draw_call) catch unreachable;
+            draw_calls_push_constants.append(.{
+                .start_instance_location = current_draw_call.start_instance_location,
+                .instance_material_buffer_index = material_buffer_index,
+                .instance_data_buffer_index = instance_data_buffer_index,
+            }) catch unreachable;
 
-                if (i == self.draw_calls_info[entity_type_index].items.len - 1) {
-                    self.draw_calls[entity_type_index].append(current_draw_call) catch unreachable;
-                    self.draw_calls_push_constants[entity_type_index].append(.{
-                        .start_instance_location = current_draw_call.start_instance_location,
-                        .instance_material_buffer_index = material_buffer_index,
-                        .instance_data_buffer_index = instance_data_buffer_index,
-                    }) catch unreachable;
-                }
+            current_draw_call = .{
+                .pipeline_id = draw_call_info.pipeline_id,
+                .mesh_handle = draw_call_info.mesh_handle,
+                .sub_mesh_index = draw_call_info.sub_mesh_index,
+                .instance_count = 1,
+                .start_instance_location = start_instance_location,
+            };
+
+            start_instance_location += 1;
+
+            if (i == self.draw_calls_info.items.len - 1) {
+                draw_calls.append(current_draw_call) catch unreachable;
+                draw_calls_push_constants.append(.{
+                    .start_instance_location = current_draw_call.start_instance_location,
+                    .instance_material_buffer_index = material_buffer_index,
+                    .instance_data_buffer_index = instance_data_buffer_index,
+                }) catch unreachable;
             }
         }
     }
-    loop2.End();
 }

--- a/src/systems/renderer_system/terrain_render_pass.zig
+++ b/src/systems/renderer_system/terrain_render_pass.zig
@@ -316,6 +316,7 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);
@@ -462,6 +463,7 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
+                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
 
                 graphics.cmdBindVertexBuffer(cmd_list, vertex_buffers.len, @constCast(&vertex_buffers), @constCast(&mesh.geometry.*.mVertexStrides), null);

--- a/src/systems/renderer_system/terrain_render_pass.zig
+++ b/src/systems/renderer_system/terrain_render_pass.zig
@@ -313,8 +313,6 @@ fn render(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
 
                 const vertex_buffers = [_][*c]graphics.Buffer{
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
@@ -460,8 +458,6 @@ fn renderShadowMap(cmd_list: [*c]graphics.Cmd, user_data: *anyopaque) void {
 
                 const vertex_buffers = [_][*c]graphics.Buffer{
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.POSITION)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.NORMAL)]].pBuffer,
-                    mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TANGENT)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.TEXCOORD0)]].pBuffer,
                     mesh.buffer.*.mVertex[mesh.buffer_layout_desc.mSemanticBindings[@intFromEnum(graphics.ShaderSemantic.COLOR)]].pBuffer,
                 };
@@ -690,7 +686,7 @@ const QuadTreeNode = struct {
 };
 
 fn loadMesh(rctx: *renderer.Renderer, path: [:0]const u8, meshes: *std.ArrayList(renderer.MeshHandle)) !void {
-    const mesh_handle = rctx.loadMesh(path) catch unreachable;
+    const mesh_handle = rctx.loadMesh(path, IdLocal.init("pos_uv0_col")) catch unreachable;
     meshes.append(mesh_handle) catch unreachable;
 }
 

--- a/sync_external.py
+++ b/sync_external.py
@@ -74,7 +74,7 @@ def main():
     sync_lib(
         "The-Forge",
         "https://github.com/gmodarelli/The-Forge.git",
-        "ee8787e7ca20008ee3d729c2212d7d222aea7e7f",
+        "f109e3d75ed3a12ee3a7f9f383c442683b0147b8",
     )
     sync_lib(
         "websocket.zig",


### PR DESCRIPTION
First steps into having support for different shaders.

This also introduces new assets, so make sure to update SVN to revision 132.

Unfortunately, the new draw call batching code is not optimized, resulting in degraded performance. I'm on it though (TM)

![Screenshot 2024-05-31 205346](https://github.com/Srekel/tides-of-revival/assets/579525/a7d8d623-29c8-43cf-b5a4-07f0a70559ec)

