### PR TITLE
AssetCompiler now writes a dep file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,6 +79,8 @@
                 "--output",
                 "${workspaceFolder}/tools/asset_compiler/src",
                 // "${workspaceFolder}/zig-out/bin/content/prefabs/environment/terrain",
+                "--dep",
+                "${workspaceFolder}/tools/asset_compiler/src/test.dep",
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/tools/binaries/asset_compiler/",


### PR DESCRIPTION
The lua function to create the texture rule becomes this (adding the DepFile line and the --dep command line option)

```lua
function CreateTextureRule(inRuleName)
    local rule =
    {
        Name = inRuleName,
        Version = 1,
        OutputPaths = { '{ Repo:Bin }{ Dir }{ File }.dds' },
        CommandLine = '{ Repo:Tools }binaries/asset_compiler/AssetCompiler.exe --input "{ Repo:Source }{ Path }" --output "{ Repo:Bin }{ Dir_NoTrailingSlash }" --dep "{ Repo:Intermediate }{ Dir }{ File }.dep"',
        InputFilters = {{ Repo = "Source", PathPattern = "*.texture" }},
        DepFile = { Path = '{ Repo:Intermediate }{ Dir }{ File }.dep', Format = 'AssetCooker' },
    }

    table.insert(Rule, rule)
end
```
