### PR TITLE
AssetCompiler is now starting texconv with -singleproc

### DIFF
--- a/tools/asset_compiler/src/main.zig
+++ b/tools/asset_compiler/src/main.zig
@@ -157,6 +157,10 @@ fn executeTextureConversionV1(desc: *TextureInfoV1, arena: std.mem.Allocator) !v
     // Do not display texconv.exe logo
     try argv.append("-nologo");
 
+    // Use a single processor
+    // AssetCooker is running one command per processor, if they all try to use all the processors, it ends up a lot slower!
+    try argv.append("-singleproc");
+
     // Compress alpha separately
     try argv.append("-sepalpha");
 


### PR DESCRIPTION
Since AssetCooker is already trying to run one command per core, many texconv.exe were trying to use all the cores, which created a lot of contention. Now they use a single core and it's a lot faster.

This is what it looked like (just one instance of texconv). Purple is sleeping, green is active. But even when active, these threads were just calling SwitchToThread (which just means "wait a little bit, let the other threads run in the meanwhile") 😅
![image](https://github.com/user-attachments/assets/f189aad0-be2d-4c9d-94c7-5828db26f6c1)

With single proc this completely disappears, most work texconv seems to do is initializing DXGI (I guess it's actually using the GPU?) and job's done in ~150ms instead of seconds.